### PR TITLE
Adding PostgreSQL queue backend to history consumer

### DIFF
--- a/history/consumer.py
+++ b/history/consumer.py
@@ -20,10 +20,18 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-RABBITMQ_URL = os.environ["RABBITMQ_URL"]
+RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "")
 DATABASE_URL = os.environ["DATABASE_URL"]
 QUEUE_NAME = "market_events"
 DEAD_QUEUE_NAME = "market_events_dead_letter"
+
+POSTGRES_QUEUE_NAME = os.environ.get("POSTGRES_QUEUE_NAME", QUEUE_NAME)
+POSTGRES_DLQ_NAME = os.environ.get("POSTGRES_DLQ_NAME", DEAD_QUEUE_NAME)
+
+RUNTIME_BACKEND = os.environ.get("RUNTIME_BACKEND", "external")
+POSTGRES_BATCH_SIZE = int(os.environ.get("POSTGRES_BATCH_SIZE", "100"))
+POSTGRES_VISIBILITY_TIMEOUT = int(os.environ.get("POSTGRES_VISIBILITY_TIMEOUT", "30"))
+
 
 INSERT_SQL = """
     INSERT INTO market_snapshots
@@ -74,6 +82,8 @@ def init_schema(conn: psycopg2.extensions.connection) -> None:
 
 
 def connect_rabbitmq() -> pika.BlockingConnection:
+    if not RABBITMQ_URL:
+        raise ValueError("RABBITMQ_URL environment variable is required for external backend")
     while True:
         try:
             params = pika.URLParameters(RABBITMQ_URL)
@@ -112,38 +122,88 @@ def send_to_dead_letter(ch, body: bytes) -> None:
         properties=pika.BasicProperties(delivery_mode=2),
     )
 
+def claim_postgres_events(db_ref: dict):
+    db = db_ref["conn"]
+    with db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT msg_id, message, read_ct
+            FROM pgmq.read(%s, %s, %s)
+            """,
+            (
+                POSTGRES_QUEUE_NAME,
+                POSTGRES_VISIBILITY_TIMEOUT,
+                POSTGRES_BATCH_SIZE,
+            ),
+        )
+        rows = cur.fetchall()
+    db.commit()
+    return rows
+
+
+
+def send_postgres_to_dead_letter(db_ref: dict, event_id, payload, error_message: str) -> None:
+    db = db_ref["conn"]
+    dlq_payload = {
+        "source_queue": POSTGRES_QUEUE_NAME,
+        "source_message_id": event_id,
+        "payload": payload,
+        "error": error_message,
+    }
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT pgmq.send(%s, %s::jsonb)",
+            (
+                POSTGRES_DLQ_NAME,
+                json.dumps(dlq_payload),
+            ),
+        )
+        cur.execute(
+            "SELECT pgmq.archive(%s, %s)",
+            (POSTGRES_QUEUE_NAME, event_id)
+        )
+    db.commit()
+
+
+def process_event_payload(db_ref: dict, data: dict) -> None:
+    msg_type = data.get("type", "market")
+
+    if msg_type == "price":
+        row = {
+            "coin": data.get("coin"),
+            "price_usd": data.get("price_usd"),
+            "change_24h": data.get("change_24h"),
+            "fetched_at": data.get("fetched_at"),
+        }
+        execute_with_reconnect(db_ref, INSERT_PRICE_SQL, row)
+        log.info("Stored price: %s $%.2f", data.get("coin"), data.get("price_usd", 0))
+        return
+
+    row = {
+            "question": data.get("question"),
+            "slug": data.get("slug"),
+            "yes_price": data.get("yes_price"),
+            "no_price": data.get("no_price"),
+            "volume_24h": data.get("volume_24h"),
+            "category": data.get("category"),
+            "end_date": data.get("end_date") or None,
+            "fetched_at": data.get("fetched_at"),
+    }
+    execute_with_reconnect(db_ref, INSERT_SQL, row)
+    log.info("Stored snapshot: %s", data.get("slug"))
+
+def ack_postgres_event(db_ref: dict, event_id) -> None:
+    db = db_ref["conn"]
+    with db.cursor() as cur:
+        cur.execute("SELECT pgmq.archive(%s, %s)", (POSTGRES_QUEUE_NAME, event_id),)
+    db.commit()
 
 def make_callback(db_ref: dict):
     def callback(ch, method, properties, body):
         try:
             data = json.loads(body)
-            msg_type = data.get("type", "market")
-
-            if msg_type == "price":
-                row = {
-                    "coin": data.get("coin"),
-                    "price_usd": data.get("price_usd"),
-                    "change_24h": data.get("change_24h"),
-                    "fetched_at": data.get("fetched_at"),
-                }
-                execute_with_reconnect(db_ref, INSERT_PRICE_SQL, row)
-                ch.basic_ack(delivery_tag=method.delivery_tag)
-                log.info("Stored price: %s $%.2f", data.get("coin"), data.get("price_usd", 0))
-                return
-
-            row = {
-                "question": data.get("question"),
-                "slug": data.get("slug"),
-                "yes_price": data.get("yes_price"),
-                "no_price": data.get("no_price"),
-                "volume_24h": data.get("volume_24h"),
-                "category": data.get("category"),
-                "end_date": data.get("end_date") or None,
-                "fetched_at": data.get("fetched_at"),
-            }
-            execute_with_reconnect(db_ref, INSERT_SQL, row)
+            process_event_payload(db_ref, data)
             ch.basic_ack(delivery_tag=method.delivery_tag)
-            log.info("Stored snapshot: %s", data.get("slug"))
         except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
             log.error("Database unavailable while processing message: %s", exc)
             ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
@@ -164,12 +224,7 @@ def make_callback(db_ref: dict):
 
     return callback
 
-
-def main() -> None:
-    db = connect_postgres()
-    init_schema(db)
-    db_ref = {"conn": db}
-
+def run_rabbitmq_worker(db_ref: dict) -> None:
     while True:
         try:
             mq = connect_rabbitmq()
@@ -187,6 +242,56 @@ def main() -> None:
             log.error("Consumer loop error: %s - reconnecting", exc)
             time.sleep(5)
             db_ref["conn"] = reconnect_postgres(db_ref.get("conn"))
+
+def run_postgres_worker(db_ref: dict) -> None:
+    while True:
+        try:
+            claimed_events = claim_postgres_events(db_ref)
+
+            if not claimed_events:
+                time.sleep(1)
+                continue
+            for event_id, payload, _attempts in claimed_events:
+                try:
+                    data = payload
+                    if isinstance(payload, str):
+                        data = json.loads(payload)
+                    process_event_payload(db_ref, data)
+                    ack_postgres_event(db_ref, event_id)
+                    log.info("Processed postgres queue event %s", event_id)
+                except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                    raise 
+                except Exception as exc:
+                    try:
+                        db_ref["conn"].rollback()
+                    except Exception:
+                        pass
+                    send_postgres_to_dead_letter(db_ref, event_id, payload, str(exc))
+                    log.error("Moved postgres queue event %s to DLQ: %s", event_id, exc)
+
+        except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+            log.error("PostgreSQL worker connection error: %s - reconnecting", exc)
+            time.sleep(5)
+            db_ref["conn"] = reconnect_postgres(db_ref.get("conn"))
+        except Exception as exc:
+            log.error("postgres worker loop error: %s - retrying in 5 sec", exc)
+            time.sleep(5)
+
+
+
+def main() -> None:
+    if RUNTIME_BACKEND not in ("external", "postgres"):
+        raise ValueError(f"Unsupported RUNTIME_BACKEND parameter: {RUNTIME_BACKEND!r}")
+
+    db = connect_postgres()
+    init_schema(db)
+    db_ref = {"conn": db}
+
+    if RUNTIME_BACKEND == "external":
+        run_rabbitmq_worker(db_ref)
+    elif RUNTIME_BACKEND == "postgres":
+        run_postgres_worker(db_ref)
+
 
 
 if __name__ == "__main__":

--- a/history/consumer.py
+++ b/history/consumer.py
@@ -25,13 +25,11 @@ DATABASE_URL = os.environ["DATABASE_URL"]
 QUEUE_NAME = "market_events"
 DEAD_QUEUE_NAME = "market_events_dead_letter"
 
-POSTGRES_QUEUE_NAME = os.environ.get("POSTGRES_QUEUE_NAME", QUEUE_NAME)
-POSTGRES_DLQ_NAME = os.environ.get("POSTGRES_DLQ_NAME", DEAD_QUEUE_NAME)
-
 RUNTIME_BACKEND = os.environ.get("RUNTIME_BACKEND", "external")
 POSTGRES_BATCH_SIZE = int(os.environ.get("POSTGRES_BATCH_SIZE", "100"))
 POSTGRES_VISIBILITY_TIMEOUT = int(os.environ.get("POSTGRES_VISIBILITY_TIMEOUT", "30"))
 
+POSTGRES_MAX_RETRIES = int(os.environ.get("POSTGRES_MAX_RETRIES", "3"))
 
 INSERT_SQL = """
     INSERT INTO market_snapshots
@@ -128,12 +126,11 @@ def claim_postgres_events(db_ref: dict):
         cur.execute(
             """
             SELECT msg_id, message, read_ct
-            FROM pgmq.read(%s, %s, %s)
+            FROM runtime.claim_events(%s, %s)
             """,
             (
-                POSTGRES_QUEUE_NAME,
-                POSTGRES_VISIBILITY_TIMEOUT,
                 POSTGRES_BATCH_SIZE,
+                POSTGRES_VISIBILITY_TIMEOUT,
             ),
         )
         rows = cur.fetchall()
@@ -141,26 +138,16 @@ def claim_postgres_events(db_ref: dict):
     return rows
 
 
-
-def send_postgres_to_dead_letter(db_ref: dict, event_id, payload, error_message: str) -> None:
+def fail_postgres_event(db_ref: dict, event_id, error_message: str) -> None:
     db = db_ref["conn"]
-    dlq_payload = {
-        "source_queue": POSTGRES_QUEUE_NAME,
-        "source_message_id": event_id,
-        "payload": payload,
-        "error": error_message,
-    }
     with db.cursor() as cur:
         cur.execute(
-            "SELECT pgmq.send(%s, %s::jsonb)",
+            "SELECT runtime.fail_event(%s, %s, %s)",
             (
-                POSTGRES_DLQ_NAME,
-                json.dumps(dlq_payload),
-            ),
-        )
-        cur.execute(
-            "SELECT pgmq.archive(%s, %s)",
-            (POSTGRES_QUEUE_NAME, event_id)
+                event_id,
+                error_message,
+                POSTGRES_MAX_RETRIES
+            )
         )
     db.commit()
 
@@ -195,7 +182,7 @@ def process_event_payload(db_ref: dict, data: dict) -> None:
 def ack_postgres_event(db_ref: dict, event_id) -> None:
     db = db_ref["conn"]
     with db.cursor() as cur:
-        cur.execute("SELECT pgmq.archive(%s, %s)", (POSTGRES_QUEUE_NAME, event_id),)
+        cur.execute("SELECT runtime.ack_event(%s)", (event_id,))
     db.commit()
 
 def make_callback(db_ref: dict):
@@ -266,8 +253,8 @@ def run_postgres_worker(db_ref: dict) -> None:
                         db_ref["conn"].rollback()
                     except Exception:
                         pass
-                    send_postgres_to_dead_letter(db_ref, event_id, payload, str(exc))
-                    log.error("Moved postgres queue event %s to DLQ: %s", event_id, exc)
+                    fail_postgres_event(db_ref, event_id, str(exc))
+                    log.error("Failed postgres queue event %s via runtime.fail_event: %s", event_id, exc)
 
         except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
             log.error("PostgreSQL worker connection error: %s - reconnecting", exc)


### PR DESCRIPTION
Task summary:
Adding backend selection to `history/consumer.py` so the history consumer can process events from either RabbitMQ  or PostgreSQL queue functions (`RUNTIME_BACKEND=external | postgres`).

Description:
 I manually verified the RabbitMQ-backed path locally:
  - `python3 -m py_compile history/main.py history/consumer.py` passed
  - started the consumer with `RUNTIME_BACKEND=external`
  - published one valid market event to RabbitMQ
  - confirmed the row was inserted into `market_snapshots`
  - started `history/main.py`
  - confirmed `/history/{slug}` returns persisted data
  - published a bad payload
  - confirmed it was dead-lettered instead of retrying forever

Current limitation:
`RUNTIME_BACKEND=postgres` is implemented on the consumer side, but end-to-end local verification is
  waiting on task #8.




  That path depends on the PostgreSQL runtime layer from ( Design PostgreSQL runtime schema and functions
  #8 ) including the required `pgmq` support / queue functions in the database environment.
  So the consumer-side postgres backend is implemented in this PR, but full runtime validation is blocked
  until task **#8** is available in the target environment.

Task status

  - [x] Add backend selection without removing RabbitMQ mode
  - [x] Implement queue claim/process/ack/fail loop
  - [x] Manual test for `external` mode
  - [x] Verify `python -m py_compile main.py consumer.py`
  - [x] Verify History API still reads persisted data
  - [ ] End-to-end verification of `RUNTIME_BACKEND=postgres` (Blocked by: #8 Design PostgreSQL runtime schema and functions)
