### PR TITLE
Feature/postgres runtime cache

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,3 +1,73 @@
-# Runtime Documentation
+# Runtime layer — operator runbook
 
-*(Placeholder - gets filled by #8a)*
+> Design rationale: see [ADR 0001](adr/0001-postgres-runtime.md). This
+> document is the operator-facing view; the ADR is the decision record.
+
+## Postgres image requirements
+
+The runtime layer depends on two extensions:
+
+- `pg_cron` — scheduled TTL reap of `runtime.cache` and `runtime.session`.
+- `pgmq` — queue primitives used by the sibling branch.
+
+Neither ships in the stock `postgres:16-alpine` image referenced by
+`deploy/compose/node-01.compose.yaml` today, so a custom image is
+required. Per ADR §9.1, the chosen base is
+`quay.io/tembo/pg16-pgmq` with `postgresql-16-cron` layered on top.
+
+At a minimum, whichever image is used, the Postgres process must start
+with:
+
+```conf
+shared_preload_libraries = 'pg_cron,pgmq'
+cron.database_name       = 'cognitor'   # optional — jobs pin themselves via schedule_in_database
+```
+
+`shared_preload_libraries` can only be changed via `postgresql.conf` (or
+an equivalent `-c` command-line flag) and requires a server restart;
+`CREATE EXTENSION` alone is not enough.
+
+## One-time bootstrap
+
+Run as a superuser, or as a role with `CREATE EXTENSION` privilege. From
+the repository root:
+
+```bash
+# 1. Pin the application role the cache/session wrappers will GRANT EXECUTE to.
+psql "$DATABASE_URL" -c "ALTER DATABASE $PGDATABASE SET runtime.app_role = 'cognitor_app';"
+
+# 2. Apply the schema, wrappers, and pg_cron schedules.
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f runtime/00_run_all.sql
+
+# 3. Verify.
+psql "$DATABASE_URL" \
+  -c "SELECT jobname, schedule, active FROM cron.job WHERE jobname LIKE 'runtime-%';"
+```
+
+Step 1 must happen **before** step 2. The wrappers in
+`runtime/07_cache_wrappers.sql` are `SECURITY DEFINER` and revoke
+`EXECUTE` from `PUBLIC` unconditionally; they only grant `EXECUTE` to the
+role named by the `runtime.app_role` GUC. If the GUC is unset at load
+time, the REVOKE runs, the GRANT is skipped, and the proxy will get
+permission-denied on its first `runtime.cache_*` call. Recover by
+setting the GUC and re-running `runtime/07_cache_wrappers.sql`.
+
+`runtime/00_run_all.sql` uses `\i` with repository-relative paths and
+must be run from the repo root.
+
+## Running the smoke tests
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f runtime/tests/test_runtime.sql
+```
+
+Seven `PASS` notices confirm that:
+
+- `cache_set` / `cache_get` / `cache_delete` round-trip correctly.
+- `cache_get` filters expired rows before the reaper runs.
+- `cache_reap` physically removes expired rows.
+- `runtime.session_*` round-trip correctly.
+- `runtime.cache` and `runtime.session` are both `UNLOGGED`.
+- All three `runtime-*` jobs are registered in `cron.job` and active.
+
+A single `FAIL` raises an exception and stops the script.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -71,3 +71,15 @@ Seven `PASS` notices confirm that:
 - All three `runtime-*` jobs are registered in `cron.job` and active.
 
 A single `FAIL` raises an exception and stops the script.
+
+## Known behaviour
+
+- `runtime-dlq-reap` (nightly at 03:00 UTC) calls `runtime.dlq_reap_expired()`,
+  which is defined on the queue side of the runtime layer
+  (`runtime/05_dlq.sql`). pg_cron stores scheduled commands as plain text and
+  does not validate them at schedule time, so the job is registered
+  successfully regardless of whether the function exists — only the firing
+  will error if it is missing. With the full bootstrap applied via
+  `runtime/00_run_all.sql` the function is present and the job succeeds; the
+  caveat is documented here in case the cache layer is ever bootstrapped in
+  isolation.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -20,12 +20,26 @@ with:
 
 ```conf
 shared_preload_libraries = 'pg_cron,pgmq'
-cron.database_name       = 'cognitor'   # optional — jobs pin themselves via schedule_in_database
+cron.database_name       = 'cognitor'   # required — launcher bgworker binds to exactly this DB
 ```
 
 `shared_preload_libraries` can only be changed via `postgresql.conf` (or
 an equivalent `-c` command-line flag) and requires a server restart;
 `CREATE EXTENSION` alone is not enough.
+
+### Why `cron.database_name` is not optional
+
+pg_cron ships as two moving parts: the `cron` schema (holding `cron.job`,
+the functions, etc.) lives in whichever database the extension was
+installed in, but the **launcher** is a single bgworker process that
+connects to exactly one database — the one named by `cron.database_name`.
+If that GUC points at a DB that does not have `pg_cron` installed,
+`cron.job` rows register successfully from anywhere, but nothing ever
+fires. Our jobs use `cron.schedule_in_database(..., current_database())`,
+which only pins the *execution* database of each job body; it does not
+change which DB the launcher watches. So on this project both must align:
+install `pg_cron` in `cognitor` and set `cron.database_name = 'cognitor'`.
+Smoke test 15 catches this misconfiguration end-to-end.
 
 ## One-time bootstrap
 
@@ -61,7 +75,7 @@ must be run from the repo root.
 psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f runtime/tests/test_runtime.sql
 ```
 
-Seven `PASS` notices confirm that:
+Eight `PASS` notices confirm that:
 
 - `cache_set` / `cache_get` / `cache_delete` round-trip correctly.
 - `cache_get` filters expired rows before the reaper runs.
@@ -69,8 +83,12 @@ Seven `PASS` notices confirm that:
 - `runtime.session_*` round-trip correctly.
 - `runtime.cache` and `runtime.session` are both `UNLOGGED`.
 - All three `runtime-*` jobs are registered in `cron.job` and active.
+- `runtime-cache-reap` actually fires — an already-expired sentinel row is
+  physically deleted by the pg_cron launcher within ~90 s (test 15).
 
-A single `FAIL` raises an exception and stops the script.
+A single `FAIL` raises an exception and stops the script. Test 15 adds
+up to ~90 s of wall time because it polls for the reaper to run; the
+other tests complete in under a second combined.
 
 ## Known behaviour
 

--- a/runtime/00_run_all.sql
+++ b/runtime/00_run_all.sql
@@ -11,9 +11,12 @@
 --     or pgmq and pg_cron must already be installed by a superuser.
 --   • Run as a role that owns (or can create objects in) the target database.
 --   • shared_preload_libraries must include 'pg_cron,pgmq' in postgresql.conf.
---   • Before running, set the application role via the GUC, 
---     e.g. ALTER DATABASE <db> SET runtime.app_role = 'cognitor_app'; 
---     otherwise [7/8] runs the REVOKE, skips the GRANT, and the proxy will 
+--   • cron.database_name in postgresql.conf must point at THIS database —
+--     the pg_cron launcher bgworker binds to exactly one DB, so jobs
+--     registered anywhere else are inert. See docs/runtime.md.
+--   • Before running, set the application role via the GUC,
+--     e.g. ALTER DATABASE <db> SET runtime.app_role = 'cognitor_app';
+--     otherwise [7/8] runs the REVOKE, skips the GRANT, and the proxy will
 --     get permission-denied at runtime.
 -- =============================================================================
 

--- a/runtime/00_run_all.sql
+++ b/runtime/00_run_all.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- runtime/00_run_all.sql
+-- Bootstrap script for the runtime cache/session layer.
+-- Use this for a fresh install or after a clean wipe.
+--
+-- Usage:
+--   psql $DATABASE_URL -f runtime/00_run_all.sql
+--
+-- Requirements:
+--   • The executing role must have CREATE EXTENSION privilege (for pg_cron),
+--     or the extension must already be installed by a superuser.
+--   • shared_preload_libraries must include 'pg_cron,pgmq' in postgresql.conf
+--     (see ADR §9).
+--
+-- Merge note:
+--   This branch (feature/postgres-runtime-cache) ships [6/8] … [8/8] only.
+--   The queue branch (postgres-runtime-queue) owns [1/5] … [5/5]. When both
+--   branches converge on dev, concatenate this file with queue's 00_run_all.sql
+--   — queue lines first, cache lines after — and update the counters to /8.
+-- =============================================================================
+
+\echo '>>> [6/8] cache/session schema + pg_cron extension'
+\i runtime/06_cache_schema.sql
+
+\echo '>>> [7/8] cache/session wrappers'
+\i runtime/07_cache_wrappers.sql
+
+\echo '>>> [8/8] pg_cron schedules'
+\i runtime/08_cron.sql
+
+\echo '>>> runtime cache/session bootstrap complete.'
+\echo '    Verify with: SELECT jobname, schedule, active FROM cron.job WHERE jobname LIKE ''runtime-%'';'

--- a/runtime/06_cache_schema.sql
+++ b/runtime/06_cache_schema.sql
@@ -2,9 +2,16 @@
 -- runtime/06_cache_schema.sql
 -- UNLOGGED cache + session tables and the pg_cron extension.
 --
--- Replaces Redis responsibilities from the proxy:
---   • whales / prices caches → runtime.cache
---   • session KV (session:{sid}) → runtime.session
+-- Purpose:
+--   • runtime.cache   — generic TTL key/value store for future callers that
+--                       need a shared, crash-truncated cache. NOT a drop-in
+--                       replacement for the proxy's whales/prices caches:
+--                       those live in sync.RWMutex-guarded memory in
+--                       proxy/main.go today, and moving them into Postgres
+--                       is out of scope for #18.
+--   • runtime.session — replaces the proxy's only current Redis use, the
+--                       `session:{sid}` KV written by /state (see
+--                       proxy/main.go handleGetState / handlePostState).
 --
 -- UNLOGGED is deliberate — cache rows should disappear on crash (same
 -- semantics as Redis without AOF). Durable rows belong elsewhere.

--- a/runtime/06_cache_schema.sql
+++ b/runtime/06_cache_schema.sql
@@ -1,0 +1,59 @@
+-- =============================================================================
+-- runtime/06_cache_schema.sql
+-- UNLOGGED cache + session tables and the pg_cron extension.
+--
+-- Replaces Redis responsibilities from the proxy:
+--   • whales / prices caches → runtime.cache
+--   • session KV (session:{sid}) → runtime.session
+--
+-- UNLOGGED is deliberate — cache rows should disappear on crash (same
+-- semantics as Redis without AOF). Durable rows belong elsewhere.
+--
+-- Run once as a superuser (or a role with CREATE EXTENSION privilege):
+--   psql $DATABASE_URL -f runtime/06_cache_schema.sql
+--
+-- Idempotent: safe to re-run on upgrades.
+-- =============================================================================
+
+-- ── Schema ────────────────────────────────────────────────────────────────────
+-- Idempotent; shared with the queue bootstrap (01_schema.sql).
+CREATE SCHEMA IF NOT EXISTS runtime;
+
+-- ── pg_cron extension ─────────────────────────────────────────────────────────
+-- Required by 08_cron.sql. The extension must be preloaded via
+--   shared_preload_libraries = 'pg_cron,pgmq'
+-- in postgresql.conf (see ADR §9). CREATE EXTENSION only registers it.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- ── runtime.cache ─────────────────────────────────────────────────────────────
+-- Generic TTL key/value store. Reads filter on expires_at so stale rows are
+-- invisible even before runtime.cache_reap() runs.
+CREATE UNLOGGED TABLE IF NOT EXISTS runtime.cache (
+    key        TEXT        PRIMARY KEY,
+    value      JSONB       NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cache_expires_at
+    ON runtime.cache (expires_at);
+
+COMMENT ON TABLE runtime.cache IS
+  'UNLOGGED key/value cache with per-row TTL. Crash-truncated by design.';
+
+-- ── runtime.session ───────────────────────────────────────────────────────────
+-- Proxy session state — replaces Redis session:{sid} keys.
+-- UNLOGGED mirrors today's behaviour (sessions die on node restart). Promote
+-- to LOGGED later if session durability becomes a requirement.
+CREATE UNLOGGED TABLE IF NOT EXISTS runtime.session (
+    sid        TEXT        PRIMARY KEY,
+    data       JSONB       NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_expires_at
+    ON runtime.session (expires_at);
+
+COMMENT ON TABLE runtime.session IS
+  'UNLOGGED session KV. Replaces Redis session:{sid}. Crash-truncated.';

--- a/runtime/07_cache_wrappers.sql
+++ b/runtime/07_cache_wrappers.sql
@@ -1,0 +1,200 @@
+-- =============================================================================
+-- runtime/07_cache_wrappers.sql
+-- High-level PL/pgSQL wrappers around runtime.cache and runtime.session.
+--
+-- Functions:
+--   runtime.cache_set   (key, value, ttl)   → VOID
+--   runtime.cache_get   (key)               → JSONB   (NULL if missing/expired)
+--   runtime.cache_delete(key)               → BOOLEAN (true on hit)
+--   runtime.cache_reap  ()                  → INT     (rows deleted)
+--
+--   runtime.session_set   (sid, data, ttl)  → VOID
+--   runtime.session_get   (sid)             → JSONB
+--   runtime.session_delete(sid)             → BOOLEAN
+--   runtime.session_reap  ()                → INT
+--
+-- All wrappers are SECURITY DEFINER so application roles only need EXECUTE on
+-- the wrapper, not direct access to the underlying tables.
+--
+-- Run after 06_cache_schema.sql.
+-- =============================================================================
+
+-- ── cache_set ────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.cache_set(
+    p_key   TEXT,
+    p_value JSONB,
+    p_ttl   INTERVAL
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+BEGIN
+    INSERT INTO runtime.cache (key, value, expires_at, updated_at)
+    VALUES (p_key, p_value, NOW() + p_ttl, NOW())
+    ON CONFLICT (key) DO UPDATE
+        SET value      = EXCLUDED.value,
+            expires_at = EXCLUDED.expires_at,
+            updated_at = EXCLUDED.updated_at;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.cache_set(TEXT, JSONB, INTERVAL) IS
+  'UPSERT a cache entry with a relative TTL (INTERVAL).';
+
+-- ── cache_get ────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.cache_get(
+    p_key TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+DECLARE
+    v_value JSONB;
+BEGIN
+    -- Filter on expires_at so expired rows are invisible even before the
+    -- reaper deletes them physically.
+    SELECT value
+    INTO   v_value
+    FROM   runtime.cache
+    WHERE  key        = p_key
+      AND  expires_at > NOW();
+
+    RETURN v_value;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.cache_get(TEXT) IS
+  'Return cache value or NULL if missing or past expires_at.';
+
+-- ── cache_delete ─────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.cache_delete(
+    p_key TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    DELETE FROM runtime.cache WHERE key = p_key;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows > 0;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.cache_delete(TEXT) IS
+  'Remove a cache entry. Returns true if a row was deleted, false otherwise.';
+
+-- ── cache_reap ───────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.cache_reap()
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    DELETE FROM runtime.cache WHERE expires_at < NOW();
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.cache_reap() IS
+  'Delete expired rows from runtime.cache. Scheduled by 08_cron.sql.';
+
+-- ── session_set ──────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.session_set(
+    p_sid  TEXT,
+    p_data JSONB,
+    p_ttl  INTERVAL
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+BEGIN
+    INSERT INTO runtime.session (sid, data, expires_at, updated_at)
+    VALUES (p_sid, p_data, NOW() + p_ttl, NOW())
+    ON CONFLICT (sid) DO UPDATE
+        SET data       = EXCLUDED.data,
+            expires_at = EXCLUDED.expires_at,
+            updated_at = EXCLUDED.updated_at;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.session_set(TEXT, JSONB, INTERVAL) IS
+  'UPSERT a session row with a relative TTL (INTERVAL).';
+
+-- ── session_get ──────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.session_get(
+    p_sid TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+DECLARE
+    v_data JSONB;
+BEGIN
+    SELECT data
+    INTO   v_data
+    FROM   runtime.session
+    WHERE  sid        = p_sid
+      AND  expires_at > NOW();
+
+    RETURN v_data;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.session_get(TEXT) IS
+  'Return session data or NULL if missing or past expires_at.';
+
+-- ── session_delete ───────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.session_delete(
+    p_sid TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    DELETE FROM runtime.session WHERE sid = p_sid;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows > 0;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.session_delete(TEXT) IS
+  'Remove a session row. Returns true if a row was deleted, false otherwise.';
+
+-- ── session_reap ─────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION runtime.session_reap()
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = runtime, public
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    DELETE FROM runtime.session WHERE expires_at < NOW();
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows;
+END;
+$$;
+
+COMMENT ON FUNCTION runtime.session_reap() IS
+  'Delete expired rows from runtime.session. Scheduled by 08_cron.sql.';

--- a/runtime/07_cache_wrappers.sql
+++ b/runtime/07_cache_wrappers.sql
@@ -101,7 +101,10 @@ AS $$
 DECLARE
     v_rows INT;
 BEGIN
-    DELETE FROM runtime.cache WHERE expires_at < NOW();
+    -- Use <= to match cache_get's strict `expires_at > NOW()`: a row with
+    -- expires_at exactly equal to NOW() is invisible to readers and should
+    -- be reaped in the same tick.
+    DELETE FROM runtime.cache WHERE expires_at <= NOW();
     GET DIAGNOSTICS v_rows = ROW_COUNT;
     RETURN v_rows;
 END;
@@ -190,7 +193,7 @@ AS $$
 DECLARE
     v_rows INT;
 BEGIN
-    DELETE FROM runtime.session WHERE expires_at < NOW();
+    DELETE FROM runtime.session WHERE expires_at <= NOW();
     GET DIAGNOSTICS v_rows = ROW_COUNT;
     RETURN v_rows;
 END;
@@ -198,3 +201,54 @@ $$;
 
 COMMENT ON FUNCTION runtime.session_reap() IS
   'Delete expired rows from runtime.session. Scheduled by 08_cron.sql.';
+
+-- ── Privilege hardening ──────────────────────────────────────────────────────
+-- SECURITY DEFINER means these functions run with the owner's rights, so we
+-- must not leave the default `GRANT EXECUTE … TO PUBLIC` in place — any role
+-- with CONNECT on this DB could otherwise invoke session_delete / cache_set
+-- etc. as the owner.
+--
+-- `runtime.app_role` is a GUC the caller sets before running this file, e.g.
+--   psql -v ON_ERROR_STOP=1 \
+--        -c "SET runtime.app_role = 'cognitor_app'" \
+--        -f runtime/07_cache_wrappers.sql
+-- or persistently via `ALTER DATABASE <db> SET runtime.app_role = '<role>';`.
+-- If unset, the DO block short-circuits and only the REVOKE runs (fail-closed
+-- default; grant explicitly later).
+REVOKE EXECUTE ON FUNCTION
+    runtime.cache_set   (TEXT, JSONB, INTERVAL),
+    runtime.cache_get   (TEXT),
+    runtime.cache_delete(TEXT),
+    runtime.cache_reap  (),
+    runtime.session_set   (TEXT, JSONB, INTERVAL),
+    runtime.session_get   (TEXT),
+    runtime.session_delete(TEXT),
+    runtime.session_reap  ()
+FROM PUBLIC;
+
+DO $$
+DECLARE
+    v_role TEXT := current_setting('runtime.app_role', true);
+BEGIN
+    IF v_role IS NULL OR v_role = '' THEN
+        RAISE NOTICE
+          'runtime.app_role not set — skipping GRANT EXECUTE. '
+          'Re-run with: SET runtime.app_role = ''<role>''; '
+          '\i runtime/07_cache_wrappers.sql (or set persistently via '
+          'ALTER DATABASE <db> SET runtime.app_role = ''<role>'';).';
+        RETURN;
+    END IF;
+
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION '
+      'runtime.cache_set(TEXT, JSONB, INTERVAL), '
+      'runtime.cache_get(TEXT), '
+      'runtime.cache_delete(TEXT), '
+      'runtime.cache_reap(), '
+      'runtime.session_set(TEXT, JSONB, INTERVAL), '
+      'runtime.session_get(TEXT), '
+      'runtime.session_delete(TEXT), '
+      'runtime.session_reap() '
+      'TO %I', v_role);
+END;
+$$;

--- a/runtime/08_cron.sql
+++ b/runtime/08_cron.sql
@@ -10,12 +10,14 @@
 -- Idempotent: each job is unscheduled (if present) before being rescheduled,
 -- so re-running this file never duplicates jobs.
 --
--- Database targeting: pg_cron jobs execute against a single database set by
--- `cron.database_name` in postgresql.conf (default: 'postgres'). Since the
--- `runtime` schema lives in the application database, we use
--- `cron.schedule_in_database(jobname, schedule, command, current_database())`
--- so the jobs run where the functions actually exist, regardless of how
--- pg_cron's default is configured.
+-- Database targeting: pg_cron runs a single launcher bgworker that binds to
+-- the database named by `cron.database_name` (default: 'postgres'). The
+-- extension, and therefore `cron.job`, must live in that database — nothing
+-- fires otherwise. `cron.schedule_in_database(..., current_database())` only
+-- pins the *execution* DB of each job body; it does NOT remove the need to
+-- point the launcher at the DB where pg_cron is installed. In this project
+-- that DB is `cognitor`, so `cron.database_name = 'cognitor'` is required,
+-- not optional. See docs/runtime.md for the full postgresql.conf block.
 --
 -- Ordering note: runtime-dlq-reap references runtime.dlq_reap_expired(), which
 -- is defined in 05_dlq.sql (queue branch). pg_cron stores the command body as

--- a/runtime/08_cron.sql
+++ b/runtime/08_cron.sql
@@ -1,0 +1,67 @@
+-- =============================================================================
+-- runtime/08_cron.sql
+-- pg_cron schedules for the runtime layer.
+--
+-- Jobs:
+--   runtime-cache-reap    — every minute
+--   runtime-session-reap  — every 5 minutes
+--   runtime-dlq-reap      — daily at 03:00 UTC
+--
+-- Idempotent: each job is unscheduled (if present) before being rescheduled,
+-- so re-running this file never duplicates jobs.
+--
+-- Ordering note: runtime-dlq-reap references runtime.dlq_reap_expired(), which
+-- is defined in 05_dlq.sql (queue branch). pg_cron stores the command body as
+-- text and does not resolve it at schedule time, so this script still succeeds
+-- when the queue files have not been loaded yet — but the first 03:00 run
+-- would fail. Load 05_dlq.sql before relying on this schedule in a merged
+-- deployment.
+--
+-- Run after 07_cache_wrappers.sql.
+-- =============================================================================
+
+-- ── runtime-cache-reap ───────────────────────────────────────────────────────
+DO $$
+BEGIN
+    PERFORM cron.unschedule(jobid)
+    FROM    cron.job
+    WHERE   jobname = 'runtime-cache-reap';
+END;
+$$;
+
+SELECT cron.schedule(
+    'runtime-cache-reap',
+    '* * * * *',
+    $$SELECT runtime.cache_reap()$$
+);
+
+-- ── runtime-session-reap ─────────────────────────────────────────────────────
+DO $$
+BEGIN
+    PERFORM cron.unschedule(jobid)
+    FROM    cron.job
+    WHERE   jobname = 'runtime-session-reap';
+END;
+$$;
+
+SELECT cron.schedule(
+    'runtime-session-reap',
+    '*/5 * * * *',
+    $$SELECT runtime.session_reap()$$
+);
+
+-- ── runtime-dlq-reap ─────────────────────────────────────────────────────────
+-- Requires runtime.dlq_reap_expired() from 05_dlq.sql (queue branch).
+DO $$
+BEGIN
+    PERFORM cron.unschedule(jobid)
+    FROM    cron.job
+    WHERE   jobname = 'runtime-dlq-reap';
+END;
+$$;
+
+SELECT cron.schedule(
+    'runtime-dlq-reap',
+    '0 3 * * *',
+    $$SELECT runtime.dlq_reap_expired('30 days')$$
+);

--- a/runtime/08_cron.sql
+++ b/runtime/08_cron.sql
@@ -10,6 +10,13 @@
 -- Idempotent: each job is unscheduled (if present) before being rescheduled,
 -- so re-running this file never duplicates jobs.
 --
+-- Database targeting: pg_cron jobs execute against a single database set by
+-- `cron.database_name` in postgresql.conf (default: 'postgres'). Since the
+-- `runtime` schema lives in the application database, we use
+-- `cron.schedule_in_database(jobname, schedule, command, current_database())`
+-- so the jobs run where the functions actually exist, regardless of how
+-- pg_cron's default is configured.
+--
 -- Ordering note: runtime-dlq-reap references runtime.dlq_reap_expired(), which
 -- is defined in 05_dlq.sql (queue branch). pg_cron stores the command body as
 -- text and does not resolve it at schedule time, so this script still succeeds
@@ -29,10 +36,11 @@ BEGIN
 END;
 $$;
 
-SELECT cron.schedule(
+SELECT cron.schedule_in_database(
     'runtime-cache-reap',
     '* * * * *',
-    $$SELECT runtime.cache_reap()$$
+    $$SELECT runtime.cache_reap()$$,
+    current_database()
 );
 
 -- ── runtime-session-reap ─────────────────────────────────────────────────────
@@ -44,10 +52,11 @@ BEGIN
 END;
 $$;
 
-SELECT cron.schedule(
+SELECT cron.schedule_in_database(
     'runtime-session-reap',
     '*/5 * * * *',
-    $$SELECT runtime.session_reap()$$
+    $$SELECT runtime.session_reap()$$,
+    current_database()
 );
 
 -- ── runtime-dlq-reap ─────────────────────────────────────────────────────────
@@ -60,8 +69,9 @@ BEGIN
 END;
 $$;
 
-SELECT cron.schedule(
+SELECT cron.schedule_in_database(
     'runtime-dlq-reap',
     '0 3 * * *',
-    $$SELECT runtime.dlq_reap_expired('30 days')$$
+    $$SELECT runtime.dlq_reap_expired('30 days')$$,
+    current_database()
 );

--- a/runtime/tests/test_runtime.sql
+++ b/runtime/tests/test_runtime.sql
@@ -405,4 +405,49 @@ BEGIN
 END;
 $$;
 
+-- ── Test 15: runtime-cache-reap fires end-to-end ────────────────────────────
+-- Test 14 only proves jobs are registered in cron.job. That is not enough:
+-- pg_cron's launcher bgworker binds to `cron.database_name`, and if that GUC
+-- points at a different DB from the one holding the `runtime` schema the jobs
+-- are registered but never execute. This test inserts an already-expired
+-- sentinel row and waits up to ~90s for the reaper to physically delete it,
+-- which exercises the full launcher → scheduler → cache_reap() → DELETE path.
+DO $$
+DECLARE
+    v_key       TEXT := '__smoke_reap_' || gen_random_uuid()::TEXT;
+    v_deadline  TIMESTAMPTZ := clock_timestamp() + INTERVAL '90 seconds';
+    v_gone      BOOLEAN := FALSE;
+    v_elapsed   INTERVAL;
+    v_started   TIMESTAMPTZ := clock_timestamp();
+BEGIN
+    INSERT INTO runtime.cache (key, value, expires_at)
+    VALUES (v_key, '{"smoke":true}'::JSONB, NOW() - INTERVAL '1 minute');
+
+    IF NOT EXISTS (SELECT 1 FROM runtime.cache WHERE key = v_key) THEN
+        RAISE EXCEPTION 'FAIL test15: sentinel row % not present after INSERT', v_key;
+    END IF;
+
+    WHILE clock_timestamp() < v_deadline LOOP
+        PERFORM pg_sleep(5);
+        IF NOT EXISTS (SELECT 1 FROM runtime.cache WHERE key = v_key) THEN
+            v_gone := TRUE;
+            EXIT;
+        END IF;
+    END LOOP;
+
+    v_elapsed := clock_timestamp() - v_started;
+
+    IF NOT v_gone THEN
+        -- Clean up before failing so a re-run of the suite is not polluted.
+        DELETE FROM runtime.cache WHERE key = v_key;
+        RAISE EXCEPTION
+            'FAIL test15: runtime-cache-reap did not remove sentinel % within %; '
+            'check that cron.database_name points at the DB holding the runtime schema',
+            v_key, v_elapsed;
+    END IF;
+
+    RAISE NOTICE 'PASS test15: runtime-cache-reap fired end-to-end in %', v_elapsed;
+END;
+$$;
+
 \echo '=== all tests passed ==='

--- a/runtime/tests/test_runtime.sql
+++ b/runtime/tests/test_runtime.sql
@@ -1,0 +1,176 @@
+-- =============================================================================
+-- runtime/tests/test_runtime.sql
+-- Smoke tests / acceptance criteria for the cache/session layer.
+--
+-- Run against a live PostgreSQL instance with the runtime schema applied:
+--   psql $DATABASE_URL -f runtime/tests/test_runtime.sql
+--
+-- Each test uses a DO block that raises EXCEPTION on failure and NOTICE on pass.
+-- =============================================================================
+
+\echo '=== runtime cache/session acceptance tests ==='
+
+-- ── Test 1: cache_set + cache_get round-trip ────────────────────────────────
+DO $$
+DECLARE
+    v_got JSONB;
+BEGIN
+    PERFORM runtime.cache_set('t1', '{"x":1}'::JSONB, '1 hour');
+    SELECT runtime.cache_get('t1') INTO v_got;
+
+    IF v_got IS NULL OR v_got <> '{"x":1}'::JSONB THEN
+        RAISE EXCEPTION 'FAIL test1: cache_get returned %, want {"x":1}', v_got;
+    END IF;
+
+    RAISE NOTICE 'PASS test1: cache_set + cache_get round-trip';
+END;
+$$;
+
+-- ── Test 2: cache_delete hit/miss semantics ─────────────────────────────────
+DO $$
+DECLARE
+    v_hit  BOOLEAN;
+    v_miss BOOLEAN;
+BEGIN
+    v_hit  := runtime.cache_delete('t1');
+    v_miss := runtime.cache_delete('t1');
+
+    IF v_hit IS NOT TRUE THEN
+        RAISE EXCEPTION 'FAIL test2: delete on existing key returned %, want true', v_hit;
+    END IF;
+
+    IF v_miss IS NOT FALSE THEN
+        RAISE EXCEPTION 'FAIL test2: delete on absent key returned %, want false', v_miss;
+    END IF;
+
+    RAISE NOTICE 'PASS test2: cache_delete hit=true / miss=false';
+END;
+$$;
+
+-- ── Test 3: cache_get filters expired rows pre-reap ─────────────────────────
+DO $$
+DECLARE
+    v_got JSONB;
+BEGIN
+    PERFORM runtime.cache_set('t3', '{"x":3}'::JSONB, '10 milliseconds');
+    PERFORM pg_sleep(0.05);
+
+    SELECT runtime.cache_get('t3') INTO v_got;
+    IF v_got IS NOT NULL THEN
+        RAISE EXCEPTION 'FAIL test3: cache_get returned % for expired row, want NULL', v_got;
+    END IF;
+
+    -- Row is still physically present — reap lives in test 4.
+    IF (SELECT COUNT(*) FROM runtime.cache WHERE key = 't3') <> 1 THEN
+        RAISE EXCEPTION 'FAIL test3: expired row missing from physical storage';
+    END IF;
+
+    RAISE NOTICE 'PASS test3: cache_get hides rows past expires_at';
+END;
+$$;
+
+-- ── Test 4: cache_reap removes expired rows ─────────────────────────────────
+DO $$
+DECLARE
+    v_reaped INT;
+    v_left   INT;
+BEGIN
+    v_reaped := runtime.cache_reap();
+
+    IF v_reaped < 1 THEN
+        RAISE EXCEPTION 'FAIL test4: cache_reap returned %, want >= 1', v_reaped;
+    END IF;
+
+    SELECT COUNT(*) INTO v_left FROM runtime.cache WHERE key = 't3';
+    IF v_left <> 0 THEN
+        RAISE EXCEPTION 'FAIL test4: runtime.cache still has % row(s) for t3 after reap', v_left;
+    END IF;
+
+    RAISE NOTICE 'PASS test4: cache_reap deleted % expired row(s)', v_reaped;
+END;
+$$;
+
+-- ── Test 5: session round-trip (set/get/delete) ─────────────────────────────
+DO $$
+DECLARE
+    v_got     JSONB;
+    v_deleted BOOLEAN;
+BEGIN
+    PERFORM runtime.session_set('sid-abc', '{"uid":42}'::JSONB, '1 hour');
+
+    SELECT runtime.session_get('sid-abc') INTO v_got;
+    IF v_got IS NULL OR v_got <> '{"uid":42}'::JSONB THEN
+        RAISE EXCEPTION 'FAIL test5: session_get returned %, want {"uid":42}', v_got;
+    END IF;
+
+    v_deleted := runtime.session_delete('sid-abc');
+    IF v_deleted IS NOT TRUE THEN
+        RAISE EXCEPTION 'FAIL test5: session_delete returned %, want true', v_deleted;
+    END IF;
+
+    RAISE NOTICE 'PASS test5: session_set + session_get + session_delete round-trip';
+END;
+$$;
+
+-- ── Test 6: cache and session tables are UNLOGGED ───────────────────────────
+DO $$
+DECLARE
+    v_cache_persistence   CHAR;
+    v_session_persistence CHAR;
+BEGIN
+    -- relpersistence: 'u' = unlogged, 'p' = permanent, 't' = temp
+    SELECT c.relpersistence
+    INTO   v_cache_persistence
+    FROM   pg_class     c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  n.nspname = 'runtime' AND c.relname = 'cache';
+
+    SELECT c.relpersistence
+    INTO   v_session_persistence
+    FROM   pg_class     c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  n.nspname = 'runtime' AND c.relname = 'session';
+
+    IF v_cache_persistence <> 'u' THEN
+        RAISE EXCEPTION 'FAIL test6: runtime.cache relpersistence = %, want u (UNLOGGED)',
+                        v_cache_persistence;
+    END IF;
+
+    IF v_session_persistence <> 'u' THEN
+        RAISE EXCEPTION 'FAIL test6: runtime.session relpersistence = %, want u (UNLOGGED)',
+                        v_session_persistence;
+    END IF;
+
+    RAISE NOTICE 'PASS test6: runtime.cache and runtime.session are UNLOGGED';
+END;
+$$;
+
+-- ── Test 7: pg_cron jobs registered ─────────────────────────────────────────
+-- Tolerant of queue files being absent: runtime-dlq-reap references
+-- runtime.dlq_reap_expired() from 05_dlq.sql (queue branch). When the cache
+-- branch is loaded standalone (without queue), 08_cron.sql still schedules
+-- the job — pg_cron does not validate the command at schedule time — so we
+-- expect exactly 3 jobs after bootstrap regardless.
+DO $$
+DECLARE
+    v_count INT;
+BEGIN
+    SELECT COUNT(*)
+    INTO   v_count
+    FROM   cron.job
+    WHERE  jobname IN (
+               'runtime-cache-reap',
+               'runtime-session-reap',
+               'runtime-dlq-reap'
+           )
+      AND  active;
+
+    IF v_count < 3 THEN
+        RAISE EXCEPTION 'FAIL test7: expected 3 active runtime-* cron jobs, got %', v_count;
+    END IF;
+
+    RAISE NOTICE 'PASS test7: % runtime-* cron jobs are scheduled and active', v_count;
+END;
+$$;
+
+\echo '=== all cache/session tests passed ==='

--- a/runtime/tests/test_runtime.sql
+++ b/runtime/tests/test_runtime.sql
@@ -245,7 +245,7 @@ $$;
 
 \echo '=== runtime cache/session acceptance tests ==='
 
--- ── Test 1: cache_set + cache_get round-trip ────────────────────────────────
+-- ── Test 8: cache_set + cache_get round-trip ────────────────────────────────
 DO $$
 DECLARE
     v_got JSONB;
@@ -254,14 +254,14 @@ BEGIN
     SELECT runtime.cache_get('t1') INTO v_got;
 
     IF v_got IS NULL OR v_got <> '{"x":1}'::JSONB THEN
-        RAISE EXCEPTION 'FAIL test1: cache_get returned %, want {"x":1}', v_got;
+        RAISE EXCEPTION 'FAIL test8: cache_get returned %, want {"x":1}', v_got;
     END IF;
 
-    RAISE NOTICE 'PASS test1: cache_set + cache_get round-trip';
+    RAISE NOTICE 'PASS test8: cache_set + cache_get round-trip';
 END;
 $$;
 
--- ── Test 2: cache_delete hit/miss semantics ─────────────────────────────────
+-- ── Test 9: cache_delete hit/miss semantics ─────────────────────────────────
 DO $$
 DECLARE
     v_hit  BOOLEAN;
@@ -271,18 +271,18 @@ BEGIN
     v_miss := runtime.cache_delete('t1');
 
     IF v_hit IS NOT TRUE THEN
-        RAISE EXCEPTION 'FAIL test2: delete on existing key returned %, want true', v_hit;
+        RAISE EXCEPTION 'FAIL test9: delete on existing key returned %, want true', v_hit;
     END IF;
 
     IF v_miss IS NOT FALSE THEN
-        RAISE EXCEPTION 'FAIL test2: delete on absent key returned %, want false', v_miss;
+        RAISE EXCEPTION 'FAIL test9: delete on absent key returned %, want false', v_miss;
     END IF;
 
-    RAISE NOTICE 'PASS test2: cache_delete hit=true / miss=false';
+    RAISE NOTICE 'PASS test9: cache_delete hit=true / miss=false';
 END;
 $$;
 
--- ── Test 3: cache_get filters expired rows pre-reap ─────────────────────────
+-- ── Test 10: cache_get filters expired rows pre-reap ────────────────────────
 DO $$
 DECLARE
     v_got JSONB;
@@ -292,19 +292,19 @@ BEGIN
 
     SELECT runtime.cache_get('t3') INTO v_got;
     IF v_got IS NOT NULL THEN
-        RAISE EXCEPTION 'FAIL test3: cache_get returned % for expired row, want NULL', v_got;
+        RAISE EXCEPTION 'FAIL test10: cache_get returned % for expired row, want NULL', v_got;
     END IF;
 
-    -- Row is still physically present — reap lives in test 4.
+    -- Row is still physically present — reap lives in test 11.
     IF (SELECT COUNT(*) FROM runtime.cache WHERE key = 't3') <> 1 THEN
-        RAISE EXCEPTION 'FAIL test3: expired row missing from physical storage';
+        RAISE EXCEPTION 'FAIL test10: expired row missing from physical storage';
     END IF;
 
-    RAISE NOTICE 'PASS test3: cache_get hides rows past expires_at';
+    RAISE NOTICE 'PASS test10: cache_get hides rows past expires_at';
 END;
 $$;
 
--- ── Test 4: cache_reap removes expired rows ─────────────────────────────────
+-- ── Test 11: cache_reap removes expired rows ────────────────────────────────
 DO $$
 DECLARE
     v_reaped INT;
@@ -313,19 +313,19 @@ BEGIN
     v_reaped := runtime.cache_reap();
 
     IF v_reaped < 1 THEN
-        RAISE EXCEPTION 'FAIL test4: cache_reap returned %, want >= 1', v_reaped;
+        RAISE EXCEPTION 'FAIL test11: cache_reap returned %, want >= 1', v_reaped;
     END IF;
 
     SELECT COUNT(*) INTO v_left FROM runtime.cache WHERE key = 't3';
     IF v_left <> 0 THEN
-        RAISE EXCEPTION 'FAIL test4: runtime.cache still has % row(s) for t3 after reap', v_left;
+        RAISE EXCEPTION 'FAIL test11: runtime.cache still has % row(s) for t3 after reap', v_left;
     END IF;
 
-    RAISE NOTICE 'PASS test4: cache_reap deleted % expired row(s)', v_reaped;
+    RAISE NOTICE 'PASS test11: cache_reap deleted % expired row(s)', v_reaped;
 END;
 $$;
 
--- ── Test 5: session round-trip (set/get/delete) ─────────────────────────────
+-- ── Test 12: session round-trip (set/get/delete) ────────────────────────────
 DO $$
 DECLARE
     v_got     JSONB;
@@ -335,19 +335,19 @@ BEGIN
 
     SELECT runtime.session_get('sid-abc') INTO v_got;
     IF v_got IS NULL OR v_got <> '{"uid":42}'::JSONB THEN
-        RAISE EXCEPTION 'FAIL test5: session_get returned %, want {"uid":42}', v_got;
+        RAISE EXCEPTION 'FAIL test12: session_get returned %, want {"uid":42}', v_got;
     END IF;
 
     v_deleted := runtime.session_delete('sid-abc');
     IF v_deleted IS NOT TRUE THEN
-        RAISE EXCEPTION 'FAIL test5: session_delete returned %, want true', v_deleted;
+        RAISE EXCEPTION 'FAIL test12: session_delete returned %, want true', v_deleted;
     END IF;
 
-    RAISE NOTICE 'PASS test5: session_set + session_get + session_delete round-trip';
+    RAISE NOTICE 'PASS test12: session_set + session_get + session_delete round-trip';
 END;
 $$;
 
--- ── Test 6: cache and session tables are UNLOGGED ───────────────────────────
+-- ── Test 13: cache and session tables are UNLOGGED ──────────────────────────
 DO $$
 DECLARE
     v_cache_persistence   CHAR;
@@ -367,20 +367,20 @@ BEGIN
     WHERE  n.nspname = 'runtime' AND c.relname = 'session';
 
     IF v_cache_persistence <> 'u' THEN
-        RAISE EXCEPTION 'FAIL test6: runtime.cache relpersistence = %, want u (UNLOGGED)',
+        RAISE EXCEPTION 'FAIL test13: runtime.cache relpersistence = %, want u (UNLOGGED)',
                         v_cache_persistence;
     END IF;
 
     IF v_session_persistence <> 'u' THEN
-        RAISE EXCEPTION 'FAIL test6: runtime.session relpersistence = %, want u (UNLOGGED)',
+        RAISE EXCEPTION 'FAIL test13: runtime.session relpersistence = %, want u (UNLOGGED)',
                         v_session_persistence;
     END IF;
 
-    RAISE NOTICE 'PASS test6: runtime.cache and runtime.session are UNLOGGED';
+    RAISE NOTICE 'PASS test13: runtime.cache and runtime.session are UNLOGGED';
 END;
 $$;
 
--- ── Test 7: pg_cron jobs registered ─────────────────────────────────────────
+-- ── Test 14: pg_cron jobs registered ────────────────────────────────────────
 -- Expect 3 active runtime-* cron jobs after bootstrap:
 -- runtime-cache-reap, runtime-session-reap, runtime-dlq-reap.
 DO $$
@@ -398,10 +398,10 @@ BEGIN
       AND  active;
 
     IF v_count < 3 THEN
-        RAISE EXCEPTION 'FAIL test7: expected 3 active runtime-* cron jobs, got %', v_count;
+        RAISE EXCEPTION 'FAIL test14: expected 3 active runtime-* cron jobs, got %', v_count;
     END IF;
 
-    RAISE NOTICE 'PASS test7: % runtime-* cron jobs are scheduled and active', v_count;
+    RAISE NOTICE 'PASS test14: % runtime-* cron jobs are scheduled and active', v_count;
 END;
 $$;
 


### PR DESCRIPTION
Closes #18

**Change summary**
- Add `runtime.cache` and `runtime.session` as UNLOGGED tables with `JSONB` + `expires_at` (`runtime/06_cache_schema.sql`).
- Add `SECURITY DEFINER` wrappers `cache_set/get/delete/reap` and `session_set/get/delete/reap`, with `REVOKE FROM PUBLIC` + GUC-gated `GRANT EXECUTE` to the role named by `runtime.app_role` (`runtime/07_cache_wrappers.sql`).
- Schedule `pg_cron` reapers via `cron.schedule_in_database(..., current_database())` — `runtime-cache-reap` every minute, `runtime-session-reap` every 5 minutes (`runtime/08_cron.sql`).
- Add bootstrap entrypoint `runtime/00_run_all.sql` and smoke tests `runtime/tests/test_runtime.sql` (7 checks covering set/get/delete, TTL filtering, reap, UNLOGGED persistence, cron registration).
- Fill `docs/runtime.md` with the operator runbook: image requirements (`shared_preload_libraries = 'pg_cron,pgmq'`), bootstrap order (GUC first), smoke-test instructions.

**Test plan**
- [ ] Start a `pg_cron`-enabled Postgres, apply `runtime/00_run_all.sql`, confirm no errors.
- [ ] Run `psql -f runtime/tests/test_runtime.sql` — 7 PASS notices.
- [ ] `SELECT jobname, schedule, active FROM cron.job WHERE jobname LIKE 'runtime-%';` — 3 active jobs.
- [ ] Insert a row with short TTL, verify `cache_get` returns NULL after expiry and the reaper deletes it within a minute.

**Carry-over list**
- None.

- [x] Docs updated
- [ ] Breaking change?
