### PR TITLE
Define local verification checks for developer changes 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,23 @@ Closes #___
 **Change summary**
 - 
 
+**Affected services** (delete lines that don't apply)
+- [ ] Frontend (`ui-react/`)
+- [ ] Go Proxy (`proxy/`)
+- [ ] Python / History (`history/`)
+- [ ] Runtime (`runtime/`)
+- [ ] Infrastructure (`ansible/`, `terraform/`, `deploy/`)
+- [ ] Docs only
+
+**Local verification** (check every box that applies — see [CONTRIBUTING.md](../CONTRIBUTING.md#before-you-open-a-pr--local-verification-checklist))
+- [ ] `make verify` passes (or ran per-service checks below)
+- [ ] Frontend: `npm run lint` + `npm run build` clean
+- [ ] Go: `go test ./...` + `go build ./...` clean
+- [ ] Python: `ruff check .` + `py_compile` clean
+- [ ] Docker: affected image(s) build successfully
+- [ ] Verified in browser / dev server (for UI changes)
+- [ ] Requires full VM/environment testing (explain below)
+
 **Test plan**
 - [ ] 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,117 @@
 - **Merge Cadence:** Changes from `dev` are merged to `main` weekly by the mentor.
 - **Commit Messages:** Follow standard semantic commit messages (e.g. `feat:`, `chore:`, `fix:`, `docs:`, `refactor:`).
 - **Merge Rules:** Use **Squash and Merge** when merging feature branches to keep the history clean.
+
+---
+
+## Before You Open a PR — Local Verification Checklist
+
+Run the checks below **for every service you touched** before pushing your PR.
+These mirror what CI runs in `.github/workflows/pr-checks.yml`, so catching
+failures locally saves a round-trip.
+
+**Quick start:** from the repo root, run `make verify` to execute all
+service checks at once, or target a single service with `make verify-ui`,
+`make verify-proxy`, or `make verify-history`.
+
+### Frontend (`ui-react/`)
+
+Run these if you changed anything under `ui-react/`:
+
+```bash
+cd ui-react
+npm ci                # clean install (or npm install if no lockfile changes)
+npm run lint          # tsc --noEmit — catches type errors
+npm run build         # production Vite build — catches import/bundling issues
+```
+
+A successful `build` is the minimum bar. If your change affects visual
+behavior, open `npm run dev` and verify the affected page in the browser.
+
+### Go Proxy (`proxy/`)
+
+Run these if you changed anything under `proxy/`:
+
+```bash
+cd proxy
+go test ./...         # unit tests
+go build ./...        # compilation check
+```
+
+Both commands must exit cleanly. `go vet ./...` is also recommended for
+catching subtle bugs, but is not currently enforced by CI.
+
+### Python / History (`history/`)
+
+Run these if you changed anything under `history/`:
+
+```bash
+cd history
+pip install -r requirements.txt ruff   # ensure deps + linter are available
+ruff check .                           # lint (default Ruff rules, no local config)
+python -m py_compile main.py consumer.py   # syntax verification
+```
+
+If you add new `.py` files, include them in the `py_compile` step.
+
+### Docker Images
+
+Run these if you changed a Dockerfile, service dependencies, or the build
+context of any image:
+
+```bash
+docker build -t coin-ops/proxy         ./proxy
+docker build -t coin-ops/history-api   -f ./history/Dockerfile.api      ./history
+docker build -t coin-ops/history-consumer -f ./history/Dockerfile.consumer ./history
+docker build -t coin-ops/ui            ./ui-react
+```
+
+You only need to build images for services you changed. A clean build with
+no errors is sufficient — you don't have to push or run the image.
+
+### Deployment / Infrastructure (`ansible/`, `terraform/`, `deploy/`)
+
+- Review changed YAML/HCL files for syntax and indentation.
+- For Ansible changes, dry-run when practical: `ansible-playbook --check ...`
+- For Compose template changes (`deploy/compose/`), verify that Jinja
+  placeholders are correct and the YAML is valid after rendering.
+
+### Cross-Service or Runtime Changes (`runtime/`)
+
+If your change spans multiple services or touches the `runtime/` directory:
+
+- Make sure **all** affected service checks above pass.
+- If the change alters the data flow between services (proxy → queue →
+  consumer → API → UI), it should be exercised through the local deployment
+  workflow or the full VM environment before merging.
+
+---
+
+## When Local Checks Are Enough
+
+Local verification is sufficient for:
+
+- Pure UI changes (styling, component logic, new pages) — lint + build + dev server.
+- Isolated Go proxy changes (new endpoint, caching tweak) — test + build.
+- Isolated Python changes (new history endpoint, consumer logic) — ruff + py_compile.
+- Documentation-only changes — no service checks needed.
+- Dockerfile changes that don't alter runtime behavior — docker build.
+
+## When You Still Need VM / Full-Environment Testing
+
+Escalate to the full VM-based deployment (`terraform` + `ansible`) when:
+
+- Your change alters **inter-service communication** (API contracts, queue
+  message format, nginx routing).
+- You modify **TLS, domain, or networking** configuration (`APP_DOMAIN`,
+  `TLS_MODE`, port mappings, UFW rules).
+- You change **Ansible playbooks or Terraform resources** that affect VM
+  provisioning or service orchestration.
+- You modify the **database schema** (`history/schema.sql`,
+  `runtime/*.sql`) — verify that migrations apply cleanly against a real
+  PostgreSQL instance.
+- You switch or extend the **runtime backend** (`RUNTIME_BACKEND`) or wire
+  new `runtime/` assets into the deployment.
+
+If in doubt, mention in your PR description that the change would benefit
+from environment-level verification, and the reviewer can coordinate testing.


### PR DESCRIPTION
Closes #32
**Change summary**
- Added a contributor-facing local verification checklist to `CONTRIBUTING.md` with per-service commands for frontend, Go proxy, Python/history, Docker, and infra-related changes.
- Added explicit guidance on when local checks are sufficient and when full VM/environment verification is required.
- Updated `.github/PULL_REQUEST_TEMPLATE.md` with `Affected services` and `Local verification` sections to standardize PR validation reporting.
**Affected services** (delete lines that don't apply)
- [ ] Frontend (`ui-react/`)
- [ ] Go Proxy (`proxy/`)
- [ ] Python / History (`history/`)
- [ ] Runtime (`runtime/`)
- [ ] Infrastructure (`ansible/`, `terraform/`, `deploy/`)
- [x] Docs only
**Local verification** (check every box that applies — see [CONTRIBUTING.md](../CONTRIBUTING.md#before-you-open-a-pr--local-verification-checklist))
- [ ] Frontend: `npm run lint` + `npm run build` clean
- [ ] Go: `go test ./...` + `go build ./...` clean
- [ ] Python: `ruff check .` + `py_compile` clean
- [ ] Docker: affected image(s) build successfully
- [ ] Verified in browser / dev server (for UI changes)
- [ ] Requires full VM/environment testing (explain below)
**Test plan**
- [x] Verified documentation updates are present in `CONTRIBUTING.md`.
- [x] Verified PR template updates are present in `.github/PULL_REQUEST_TEMPLATE.md`.
- [x] Confirmed scope remains documentation-only and does not introduce local deployment tooling from issue #31.
**Carry-over list**
- None
- [x] Docs updated
- [ ] Breaking change?