### PR TITLE
test: add fast Python unit suite for history services

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,17 @@ psql "$DATABASE_URL" -f runtime/00_run_all.sql
 python runtime/runtime_consumer.py
 ```
 
+Fast Python unit tests for both the current `external` path and the PostgreSQL runtime target:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r history/requirements-dev.txt
+pytest
+```
+
+The fast `pytest` suite lives under `tests/python/unit`. Keep PostgreSQL-backed integration coverage separate from these unit tests.
+
 ## External Data Sources
 
 | Source | Data |

--- a/README.md
+++ b/README.md
@@ -281,11 +281,14 @@ python runtime/runtime_consumer.py
 Fast Python unit tests for both the current `external` path and the PostgreSQL runtime target:
 
 ```bash
+cd <repo-root>
 python -m venv venv
 source venv/bin/activate
 pip install -r history/requirements-dev.txt
-pytest
+python -m pytest tests/python/unit
 ```
+
+If you are already in `history/`, either `cd ..` first or run `python -m pytest ../tests/python/unit`.
 
 The fast `pytest` suite lives under `tests/python/unit`. Keep PostgreSQL-backed integration coverage separate from these unit tests.
 

--- a/history/pytest.ini
+++ b/history/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = ../tests/python/unit

--- a/history/requirements-dev.txt
+++ b/history/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests/python/unit

--- a/tests/python/unit/conftest.py
+++ b/tests/python/unit/conftest.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import signal
 import uuid
 from pathlib import Path
 
@@ -7,11 +8,15 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+RESTORED_SIGNALS = tuple(
+    sig for sig in (signal.SIGINT, getattr(signal, "SIGTERM", None)) if sig is not None
+)
 
 
 def load_module(relative_path: str, env: dict[str, str]):
     module_path = REPO_ROOT / relative_path
     previous_values = {key: os.environ.get(key) for key in env}
+    previous_signal_handlers = {sig: signal.getsignal(sig) for sig in RESTORED_SIGNALS}
 
     try:
         for key, value in env.items():
@@ -29,6 +34,9 @@ def load_module(relative_path: str, env: dict[str, str]):
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = old_value
+
+        for sig, handler in previous_signal_handlers.items():
+            signal.signal(sig, handler)
 
 
 def description_from_names(*names: str):

--- a/tests/python/unit/conftest.py
+++ b/tests/python/unit/conftest.py
@@ -1,0 +1,122 @@
+import importlib.util
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_module(relative_path: str, env: dict[str, str]):
+    module_path = REPO_ROOT / relative_path
+    previous_values = {key: os.environ.get(key) for key in env}
+
+    try:
+        for key, value in env.items():
+            os.environ[key] = value
+
+        module_name = f"test_{module_path.stem}_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for key, old_value in previous_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+def description_from_names(*names: str):
+    return [(name, None, None, None, None, None, None) for name in names]
+
+
+class CursorSpy:
+    def __init__(self, rows=None, description=None):
+        self.rows = rows or []
+        self.description = description or []
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return list(self.rows)
+
+    def fetchone(self):
+        if not self.rows:
+            return None
+        return self.rows[0]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class ConnectionSpy:
+    def __init__(self, rows=None, description=None):
+        self.cursor_obj = CursorSpy(rows=rows, description=description)
+        self.closed = False
+        self.rollback_calls = 0
+        self.commit_calls = 0
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def close(self):
+        self.closed = True
+
+    def rollback(self):
+        self.rollback_calls += 1
+
+    def commit(self):
+        self.commit_calls += 1
+
+
+class ChannelSpy:
+    def __init__(self):
+        self.acks = []
+        self.nacks = []
+        self.published = []
+
+    def basic_ack(self, delivery_tag):
+        self.acks.append(delivery_tag)
+
+    def basic_nack(self, delivery_tag, requeue):
+        self.nacks.append((delivery_tag, requeue))
+
+    def basic_publish(self, *args, **kwargs):
+        self.published.append((args, kwargs))
+
+
+@pytest.fixture
+def history_main_module():
+    return load_module(
+        "history/main.py",
+        {"DATABASE_URL": "postgresql://coinops:test@localhost:5432/coinops"},
+    )
+
+
+@pytest.fixture
+def history_consumer_module():
+    return load_module(
+        "history/consumer.py",
+        {
+            "DATABASE_URL": "postgresql://coinops:test@localhost:5432/coinops",
+            "RABBITMQ_URL": "amqp://guest:guest@localhost:5672/",
+        },
+    )
+
+
+@pytest.fixture
+def runtime_consumer_module():
+    return load_module(
+        "runtime/runtime_consumer.py",
+        {"DATABASE_URL": "postgresql://coinops:test@localhost:5432/coinops"},
+    )

--- a/tests/python/unit/test_history_api.py
+++ b/tests/python/unit/test_history_api.py
@@ -1,0 +1,72 @@
+import pytest
+
+from conftest import ConnectionSpy
+
+
+def test_get_history_without_category_uses_recent_query(history_main_module, monkeypatch):
+    conn = ConnectionSpy(rows=[{"id": 1, "slug": "btc-100k", "category": "crypto"}])
+    monkeypatch.setattr(history_main_module, "get_db", lambda: conn)
+
+    result = history_main_module.get_history(limit=3, category=None)
+
+    sql, params = conn.cursor_obj.executed[0]
+    assert result == [{"id": 1, "slug": "btc-100k", "category": "crypto"}]
+    assert "FROM market_snapshots" in sql
+    assert "WHERE category ILIKE %s" not in sql
+    assert params == (3,)
+    assert conn.closed is True
+
+
+def test_get_history_with_category_uses_ilike_filter(history_main_module, monkeypatch):
+    conn = ConnectionSpy(rows=[{"id": 2, "slug": "sports-bet", "category": "sports"}])
+    monkeypatch.setattr(history_main_module, "get_db", lambda: conn)
+
+    result = history_main_module.get_history(limit=5, category="sports")
+
+    sql, params = conn.cursor_obj.executed[0]
+    assert result == [{"id": 2, "slug": "sports-bet", "category": "sports"}]
+    assert "WHERE category ILIKE %s" in sql
+    assert params == ("%sports%", 5)
+    assert conn.closed is True
+
+
+def test_get_market_history_raises_404_when_market_missing(history_main_module, monkeypatch):
+    conn = ConnectionSpy(rows=[])
+    monkeypatch.setattr(history_main_module, "get_db", lambda: conn)
+
+    with pytest.raises(history_main_module.HTTPException) as exc:
+        history_main_module.get_market_history("missing-market", limit=10)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Market not found"
+    assert conn.closed is True
+
+
+def test_get_price_history_uses_coin_filter_and_serializes_rows(history_main_module, monkeypatch):
+    conn = ConnectionSpy(
+        rows=[
+            {
+                "fetched_at": "2026-04-23T12:00:00Z",
+                "coin": "bitcoin",
+                "price_usd": 97000.0,
+                "change_24h": -1.2,
+            }
+        ]
+    )
+    monkeypatch.setattr(history_main_module, "get_db", lambda: conn)
+
+    result = history_main_module.get_price_history("bitcoin", limit=72)
+
+    sql, params = conn.cursor_obj.executed[0]
+    assert result == [
+        {
+            "fetched_at": "2026-04-23T12:00:00Z",
+            "coin": "bitcoin",
+            "price_usd": 97000.0,
+            "change_24h": -1.2,
+        }
+    ]
+    assert "FROM price_snapshots" in sql
+    assert "WHERE coin = %s" in sql
+    assert params == ("bitcoin", 72)
+    assert conn.closed is True

--- a/tests/python/unit/test_history_consumer.py
+++ b/tests/python/unit/test_history_consumer.py
@@ -1,0 +1,177 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import ChannelSpy, ConnectionSpy
+
+
+def test_market_messages_route_to_market_insert(history_consumer_module, monkeypatch):
+    executed = []
+    monkeypatch.setattr(
+        history_consumer_module,
+        "execute_with_reconnect",
+        lambda db_ref, sql, row: executed.append((sql, row)),
+    )
+
+    channel = ChannelSpy()
+    callback = history_consumer_module.make_callback({"conn": ConnectionSpy()})
+    body = json.dumps(
+        {
+            "question": "Will BTC reach 100k?",
+            "slug": "btc-100k",
+            "yes_price": 0.61,
+            "no_price": 0.39,
+            "volume_24h": 1234,
+            "category": "crypto",
+            "end_date": "",
+            "fetched_at": "2026-04-23T12:00:00Z",
+        }
+    ).encode()
+
+    callback(channel, SimpleNamespace(delivery_tag=11), None, body)
+
+    sql, row = executed[0]
+    assert sql == history_consumer_module.INSERT_SQL
+    assert row["slug"] == "btc-100k"
+    assert row["end_date"] is None
+    assert channel.acks == [11]
+    assert channel.nacks == []
+
+
+def test_price_messages_route_to_price_insert(history_consumer_module, monkeypatch):
+    executed = []
+    monkeypatch.setattr(
+        history_consumer_module,
+        "execute_with_reconnect",
+        lambda db_ref, sql, row: executed.append((sql, row)),
+    )
+
+    channel = ChannelSpy()
+    callback = history_consumer_module.make_callback({"conn": ConnectionSpy()})
+    body = json.dumps(
+        {
+            "type": "price",
+            "coin": "bitcoin",
+            "price_usd": 97000.0,
+            "change_24h": -1.2,
+            "fetched_at": "2026-04-23T12:00:00Z",
+        }
+    ).encode()
+
+    callback(channel, SimpleNamespace(delivery_tag=12), None, body)
+
+    sql, row = executed[0]
+    assert sql == history_consumer_module.INSERT_PRICE_SQL
+    assert row["coin"] == "bitcoin"
+    assert row["price_usd"] == 97000.0
+    assert channel.acks == [12]
+    assert channel.nacks == []
+
+
+def test_invalid_json_is_dead_lettered_and_acked(history_consumer_module, monkeypatch):
+    conn = ConnectionSpy()
+    dead_letter_bodies = []
+    monkeypatch.setattr(
+        history_consumer_module,
+        "send_to_dead_letter",
+        lambda channel, body: dead_letter_bodies.append(body),
+    )
+
+    channel = ChannelSpy()
+    callback = history_consumer_module.make_callback({"conn": conn})
+
+    callback(channel, SimpleNamespace(delivery_tag=13), None, b"{not-json")
+
+    assert dead_letter_bodies == [b"{not-json"]
+    assert conn.rollback_calls == 1
+    assert channel.acks == [13]
+    assert channel.nacks == []
+
+
+def test_database_disconnect_requeues_message(history_consumer_module, monkeypatch):
+    def raise_operational_error(*args, **kwargs):
+        raise history_consumer_module.psycopg2.OperationalError("db down")
+
+    monkeypatch.setattr(history_consumer_module, "execute_with_reconnect", raise_operational_error)
+
+    channel = ChannelSpy()
+    callback = history_consumer_module.make_callback({"conn": ConnectionSpy()})
+    body = json.dumps({"slug": "btc-100k", "yes_price": 0.61}).encode()
+
+    with pytest.raises(history_consumer_module.psycopg2.OperationalError):
+        callback(channel, SimpleNamespace(delivery_tag=14), None, body)
+
+    assert channel.acks == []
+    assert channel.nacks == [(14, True)]
+
+
+def test_dead_letter_publish_failure_requeues_message(history_consumer_module, monkeypatch):
+    def raise_dead_letter_error(*args, **kwargs):
+        raise RuntimeError("dlq unavailable")
+
+    monkeypatch.setattr(history_consumer_module, "send_to_dead_letter", raise_dead_letter_error)
+
+    channel = ChannelSpy()
+    callback = history_consumer_module.make_callback({"conn": ConnectionSpy()})
+
+    with pytest.raises(RuntimeError):
+        callback(channel, SimpleNamespace(delivery_tag=15), None, b"{not-json")
+
+    assert channel.acks == []
+    assert channel.nacks == [(15, True)]
+
+
+def test_execute_with_reconnect_swaps_in_new_connection(history_consumer_module, monkeypatch):
+    class ReconnectConnection:
+        def __init__(self, error=None):
+            self.error = error
+            self.rollback_calls = 0
+            self.commit_calls = 0
+            self.executed = []
+
+        def cursor(self):
+            return self
+
+        def execute(self, sql, row):
+            self.executed.append((sql, row))
+            if self.error is not None:
+                error = self.error
+                self.error = None
+                raise error
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def rollback(self):
+            self.rollback_calls += 1
+
+        def commit(self):
+            self.commit_calls += 1
+
+    first_conn = ReconnectConnection(
+        error=history_consumer_module.psycopg2.OperationalError("connection dropped")
+    )
+    second_conn = ReconnectConnection()
+    db_ref = {"conn": first_conn}
+
+    monkeypatch.setattr(history_consumer_module, "reconnect_postgres", lambda old_conn: second_conn)
+
+    history_consumer_module.execute_with_reconnect(
+        db_ref,
+        history_consumer_module.INSERT_SQL,
+        {"slug": "btc-100k", "yes_price": 0.61},
+    )
+
+    assert first_conn.rollback_calls == 1
+    assert second_conn.executed == [
+        (
+            history_consumer_module.INSERT_SQL,
+            {"slug": "btc-100k", "yes_price": 0.61},
+        )
+    ]
+    assert second_conn.commit_calls == 1
+    assert db_ref["conn"] is second_conn

--- a/tests/python/unit/test_runtime_consumer.py
+++ b/tests/python/unit/test_runtime_consumer.py
@@ -1,0 +1,134 @@
+import json
+
+import pytest
+
+from conftest import ConnectionSpy, description_from_names
+
+
+def test_process_message_routes_market_payload_and_acks(runtime_consumer_module):
+    conn = ConnectionSpy()
+
+    runtime_consumer_module.process_message(
+        conn,
+        101,
+        {
+            "question": "Will BTC reach 100k?",
+            "slug": "btc-100k",
+            "yes_price": 0.61,
+            "no_price": 0.39,
+            "volume_24h": 1234,
+            "category": "crypto",
+            "end_date": "",
+            "fetched_at": "2026-04-23T12:00:00Z",
+        },
+    )
+
+    insert_sql, row = conn.cursor_obj.executed[0]
+    ack_sql, ack_params = conn.cursor_obj.executed[1]
+    assert insert_sql == runtime_consumer_module.INSERT_MARKET
+    assert row["slug"] == "btc-100k"
+    assert row["end_date"] is None
+    assert ack_sql == runtime_consumer_module.SQL_ACK
+    assert ack_params == (101,)
+
+
+def test_process_message_routes_price_payload_and_acks(runtime_consumer_module):
+    conn = ConnectionSpy()
+
+    runtime_consumer_module.process_message(
+        conn,
+        102,
+        {
+            "type": "price",
+            "coin": "bitcoin",
+            "price_usd": 97000.0,
+            "change_24h": -1.2,
+            "fetched_at": "2026-04-23T12:00:00Z",
+        },
+    )
+
+    insert_sql, row = conn.cursor_obj.executed[0]
+    ack_sql, ack_params = conn.cursor_obj.executed[1]
+    assert insert_sql == runtime_consumer_module.INSERT_PRICE
+    assert row["coin"] == "bitcoin"
+    assert row["price_usd"] == 97000.0
+    assert ack_sql == runtime_consumer_module.SQL_ACK
+    assert ack_params == (102,)
+
+
+def test_drain_batch_decodes_string_payloads(runtime_consumer_module, monkeypatch):
+    payload = {
+        "type": "price",
+        "coin": "bitcoin",
+        "price_usd": 97000.0,
+        "change_24h": -1.2,
+        "fetched_at": "2026-04-23T12:00:00Z",
+    }
+    conn = ConnectionSpy(
+        rows=[(201, 0, None, None, json.dumps(payload))],
+        description=description_from_names("msg_id", "read_ct", "enqueued_at", "vt", "message"),
+    )
+    seen = []
+    monkeypatch.setattr(
+        runtime_consumer_module,
+        "process_message",
+        lambda conn, msg_id, payload: seen.append((msg_id, payload)),
+    )
+
+    processed = runtime_consumer_module.drain_batch(conn)
+
+    sql, params = conn.cursor_obj.executed[0]
+    assert processed == 1
+    assert seen == [(201, payload)]
+    assert sql == runtime_consumer_module.SQL_CLAIM
+    assert params == (
+        runtime_consumer_module.BATCH_SIZE,
+        runtime_consumer_module.VT_SECONDS,
+    )
+
+
+def test_drain_batch_sends_malformed_json_to_fail_path(runtime_consumer_module, monkeypatch):
+    conn = ConnectionSpy(
+        rows=[(202, 0, None, None, "{not-json")],
+        description=description_from_names("msg_id", "read_ct", "enqueued_at", "vt", "message"),
+    )
+    failures = []
+    monkeypatch.setattr(
+        runtime_consumer_module,
+        "process_message",
+        lambda *args, **kwargs: pytest.fail("process_message should not run for malformed JSON"),
+    )
+    monkeypatch.setattr(
+        runtime_consumer_module,
+        "handle_failure",
+        lambda conn, msg_id, error: failures.append((msg_id, error)),
+    )
+
+    processed = runtime_consumer_module.drain_batch(conn)
+
+    assert processed == 0
+    assert failures[0][0] == 202
+    assert "JSONDecodeError" in failures[0][1]
+
+
+def test_drain_batch_reports_processing_failures(runtime_consumer_module, monkeypatch):
+    conn = ConnectionSpy(
+        rows=[(203, 0, None, None, {"slug": "btc-100k", "yes_price": 0.61})],
+        description=description_from_names("msg_id", "read_ct", "enqueued_at", "vt", "message"),
+    )
+    failures = []
+
+    def raise_processing_error(conn, msg_id, payload):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(runtime_consumer_module, "process_message", raise_processing_error)
+    monkeypatch.setattr(
+        runtime_consumer_module,
+        "handle_failure",
+        lambda conn, msg_id, error: failures.append((msg_id, error)),
+    )
+
+    processed = runtime_consumer_module.drain_batch(conn)
+
+    assert processed == 0
+    assert failures == [(203, "boom")]


### PR DESCRIPTION
Closes #35

**Change summary**
- Add a fast `pytest` unit suite under `tests/python/unit` for the history API query/read contract.
- Cover the current RabbitMQ-backed `history/consumer.py` path for market routing, price routing, reconnect behavior, invalid JSON, and dead-letter/requeue branches.
- Cover the PostgreSQL runtime target in `runtime/runtime_consumer.py` so the suite protects the migration direction already defined in the repo docs/issues, not just today?s deployed path.
- Add repo-level `pytest.ini` plus `history/requirements-dev.txt` so contributors can install and run the Python unit suite locally without PostgreSQL, RabbitMQ, or Docker Compose.
- Document the fast Python unit-test command in `README.md` and explicitly keep these unit tests separate from future PostgreSQL-backed integration tests.

**Test plan**
- [x] `python -m venv .venv`
- [x] `.\\.venv\\Scripts\\python -m pip install -r history\\requirements-dev.txt`
- [x] `.\\.venv\\Scripts\\python -m pytest`

**Carry-over list**
- No production behavior changes are included in this branch; the scope is test/docs/config only so it stays low-conflict with the team?s in-flight consumer migration work.
- The suite is intentionally future-facing: it covers both the current `external` consumer path and the PostgreSQL runtime consumer path already present in `runtime/`, which matches the direction described across issues `#8`, `#10`, `#11`, `#18`, and the architecture/runtime docs.

- [x] Docs updated
- [ ] Breaking change?
