### PR TITLE
test: add Go unit tests for pure logic, middleware and HTTP handlers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Use TypeScript for React UI code and keep components in `ui-react/src/`. Prefer 
 
 ## Testing Guidelines
 
-There is no full automated test suite yet. Minimum verification before committing UI changes is `npm run lint` and `npm run build` in `ui-react/`. For Go changes, run `go test ./...` or `make build` from `proxy/`. For deployment changes, prefer Ansible dry-run/checks where practical and inspect affected Compose files manually.
+There is no full automated test suite yet. Minimum verification before committing UI changes is `npm run lint` and `npm run build` in `ui-react/`. For Go changes, run `go test ./...` (or `go test -v -race ./...` when touching concurrency/state behavior) and `go build ./...` from `proxy/`. For deployment changes, prefer Ansible dry-run/checks where practical and inspect affected Compose files manually.
 
 ## Commit & Pull Request Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ cd proxy
 make build    # cross-compile → proxy-linux (GOOS=linux GOARCH=amd64)
 make run      # local run
 make tidy     # go mod tidy
+go test ./... # fast unit tests (no Docker/Redis/RabbitMQ/PostgreSQL required)
 ```
 
 ### UI (React)

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type mockStateStore struct {
+	data   map[string][]byte
+	getErr error
+	setErr error
+}
+
+func (m *mockStateStore) GetState(_ context.Context, sid string) ([]byte, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	v, ok := m.data[sid]
+	if !ok {
+		return nil, ErrStateNotFound
+	}
+	return append([]byte(nil), v...), nil
+}
+
+func (m *mockStateStore) SetState(_ context.Context, sid string, value []byte) error {
+	if m.setErr != nil {
+		return m.setErr
+	}
+	if m.data == nil {
+		m.data = make(map[string][]byte)
+	}
+	m.data[sid] = append([]byte(nil), value...)
+	return nil
+}
+
+func newTestServer() *Server {
+	return &Server{
+		backend: "external",
+		state:   &mockStateStore{data: make(map[string][]byte)},
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHealth(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if strings.TrimSpace(rr.Body.String()) != `{"status":"ok"}` {
+		t.Fatalf("body = %s", rr.Body.String())
+	}
+}
+
+func TestHandleWhales(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns cached whales", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		srv.cache.Lock()
+		srv.cache.whales = []Whale{{Pseudonym: "A", Address: "0x1", Pnl: 1.2, Volume: 3.4, Rank: 1}}
+		srv.cache.Unlock()
+
+		req := httptest.NewRequest(http.MethodGet, "/whales", nil)
+		rr := httptest.NewRecorder()
+		srv.handleWhales(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if !strings.Contains(rr.Body.String(), `"pseudonym":"A"`) {
+			t.Fatalf("unexpected body: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("empty cache returns null", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodGet, "/whales", nil)
+		rr := httptest.NewRecorder()
+		srv.handleWhales(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if strings.TrimSpace(rr.Body.String()) != "null" {
+			t.Fatalf("body = %q, want null", strings.TrimSpace(rr.Body.String()))
+		}
+	})
+}
+
+func TestHandlePrices(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer()
+	now := time.Now().UTC()
+
+	srv.cache.Lock()
+	srv.cache.prices = Prices{
+		BtcUsd:       1,
+		EthUsd:       2,
+		Btc24hChange: 3,
+		Eth24hChange: 4,
+		UsdUah:       5,
+		FetchedAt:    now,
+	}
+	srv.cache.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/prices", nil)
+	rr := httptest.NewRecorder()
+	srv.handlePrices(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), `"btc_usd":1`) || !strings.Contains(rr.Body.String(), `"usd_uah":5`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestHandleCurrent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns cached markets", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		srv.cache.Lock()
+		srv.cache.markets = []MarketSnapshot{{Slug: "m1", Question: "Q1"}}
+		srv.cache.Unlock()
+
+		req := httptest.NewRequest(http.MethodGet, "/current", nil)
+		rr := httptest.NewRecorder()
+		srv.handleCurrent(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if !strings.Contains(rr.Body.String(), `"slug":"m1"`) {
+			t.Fatalf("unexpected body: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("empty cache and fetch failure returns 502", func(t *testing.T) {
+		// Not parallel: patches the package-level httpClient.
+		srv := newTestServer()
+
+		origClient := httpClient
+		httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("simulated network failure")
+		})}
+		t.Cleanup(func() { httpClient = origClient })
+
+		req := httptest.NewRequest(http.MethodGet, "/current", nil)
+		rr := httptest.NewRecorder()
+		srv.handleCurrent(rr, req)
+
+		if rr.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadGateway)
+		}
+	})
+}
+
+func TestHandleStateRouting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get routes to get handler", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		newTestServer().handleState(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if strings.TrimSpace(rr.Body.String()) != "{}" {
+			t.Fatalf("unexpected body: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("post routes to post handler", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=abcd1234", strings.NewReader(`{"x":1}`))
+		rr := httptest.NewRecorder()
+		newTestServer().handleState(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("put returns 405", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPut, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		newTestServer().handleState(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
+		}
+	})
+
+	t.Run("delete returns 405", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodDelete, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		newTestServer().handleState(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func TestHandleGetState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing sid returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodGet, "/state", nil)
+		rr := httptest.NewRecorder()
+		srv.handleGetState(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid sid returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodGet, "/state?sid=bad!sid", nil)
+		rr := httptest.NewRecorder()
+		srv.handleGetState(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("state not found returns empty object", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodGet, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		srv.handleGetState(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if strings.TrimSpace(rr.Body.String()) != "{}" {
+			t.Fatalf("body = %q, want {}", strings.TrimSpace(rr.Body.String()))
+		}
+	})
+
+	t.Run("stored state returns json", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		store := srv.state.(*mockStateStore)
+		store.data["abcd1234"] = []byte(`{"a":1}`)
+		req := httptest.NewRequest(http.MethodGet, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		srv.handleGetState(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if strings.TrimSpace(rr.Body.String()) != `{"a":1}` {
+			t.Fatalf("body = %q", strings.TrimSpace(rr.Body.String()))
+		}
+	})
+
+	t.Run("store error returns 503", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		srv.state = &mockStateStore{getErr: errors.New("boom")}
+		req := httptest.NewRequest(http.MethodGet, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		srv.handleGetState(rr, req)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
+		}
+	})
+}
+
+func TestHandlePostState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing sid returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodPost, "/state", strings.NewReader(`{"a":1}`))
+		rr := httptest.NewRecorder()
+		srv.handlePostState(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid sid returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=bad!sid", strings.NewReader(`{"a":1}`))
+		rr := httptest.NewRecorder()
+		srv.handlePostState(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid json body returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=abcd1234", strings.NewReader(`{bad`))
+		rr := httptest.NewRecorder()
+		srv.handlePostState(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("valid json stores value and returns 200", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=abcd1234", strings.NewReader(`{"a":1}`))
+		rr := httptest.NewRecorder()
+		srv.handlePostState(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+
+		store := srv.state.(*mockStateStore)
+		if got := string(store.data["abcd1234"]); got != `{"a":1}` {
+			t.Fatalf("stored value = %q, want %q", got, `{"a":1}`)
+		}
+	})
+
+	t.Run("oversized body is limited and fails json validation", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		large := `{"x":"` + strings.Repeat("a", 5000) + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=abcd1234", strings.NewReader(large))
+		rr := httptest.NewRecorder()
+		srv.handlePostState(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("store error returns 503", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer()
+		srv.state = &mockStateStore{setErr: errors.New("boom")}
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=abcd1234", strings.NewReader(`{"a":1}`))
+		rr := httptest.NewRecorder()
+		srv.handlePostState(rr, req)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestFetchJSONUsesConfiguredTransport(t *testing.T) {
+	// Not parallel: patches the package-level httpClient.
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`[]`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	orig := httpClient
+	httpClient = client
+	t.Cleanup(func() { httpClient = orig })
+
+	var out []json.RawMessage
+	if err := fetchJSON("http://example.invalid", &out); err != nil {
+		t.Fatalf("fetchJSON returned error: %v", err)
+	}
+}

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestToFloat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   interface{}
+		want float64
+	}{
+		{name: "float64", in: 3.14, want: 3.14},
+		{name: "string", in: "42.5", want: 42.5},
+		{name: "json number", in: json.Number("99"), want: 99},
+		{name: "invalid string", in: "abc", want: 0},
+		{name: "empty string", in: "", want: 0},
+		{name: "nil", in: nil, want: 0},
+		{name: "unsupported type", in: true, want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := toFloat(tc.in)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Fatalf("toFloat(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseOutcomePrices(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     json.RawMessage
+		wantYes float64
+		wantNo  float64
+	}{
+		{
+			name:    "direct array",
+			raw:     json.RawMessage(`["0.62","0.38"]`),
+			wantYes: 0.62,
+			wantNo:  0.38,
+		},
+		{
+			name:    "stringified array",
+			raw:     json.RawMessage(`"[\"0.62\",\"0.38\"]"`),
+			wantYes: 0.62,
+			wantNo:  0.38,
+		},
+		{
+			name:    "single element",
+			raw:     json.RawMessage(`["0.75"]`),
+			wantYes: 0.75,
+			wantNo:  0,
+		},
+		{
+			name:    "empty array",
+			raw:     json.RawMessage(`[]`),
+			wantYes: 0,
+			wantNo:  0,
+		},
+		{
+			name:    "null",
+			raw:     json.RawMessage(`null`),
+			wantYes: 0,
+			wantNo:  0,
+		},
+		{
+			name:    "invalid json",
+			raw:     json.RawMessage(`{bad`),
+			wantYes: 0,
+			wantNo:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotYes, gotNo := parseOutcomePrices(tc.raw)
+			if math.Abs(gotYes-tc.wantYes) > 1e-9 || math.Abs(gotNo-tc.wantNo) > 1e-9 {
+				t.Fatalf(
+					"parseOutcomePrices(%s) = (%v,%v), want (%v,%v)",
+					tc.raw, gotYes, gotNo, tc.wantYes, tc.wantNo,
+				)
+			}
+		})
+	}
+}
+
+func TestNormalizeMarket(t *testing.T) {
+	t.Parallel()
+
+	fetchedAt := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("full normalization", func(t *testing.T) {
+		t.Parallel()
+
+		in := GammaMarket{
+			Question:      "Will BTC exceed 100k?",
+			Slug:          "btc-100k",
+			OutcomePrices: json.RawMessage(`["0.62","0.38"]`),
+			Volume24hr:    "1234.5",
+			EndDateIso:    "2026-12-31T23:59:59Z",
+			Category:      "Crypto",
+		}
+
+		got := normalizeMarket(in, fetchedAt)
+		if got.Question != in.Question || got.Slug != in.Slug || got.Category != in.Category || got.EndDate != in.EndDateIso {
+			t.Fatalf("normalizeMarket() basic fields mismatch: got %+v", got)
+		}
+		if math.Abs(got.YesPrice-0.62) > 1e-9 || math.Abs(got.NoPrice-0.38) > 1e-9 {
+			t.Fatalf("normalizeMarket() prices mismatch: got yes=%v no=%v", got.YesPrice, got.NoPrice)
+		}
+		if math.Abs(got.Volume24h-1234.5) > 1e-9 {
+			t.Fatalf("normalizeMarket() volume mismatch: got %v", got.Volume24h)
+		}
+		if !got.FetchedAt.Equal(fetchedAt) {
+			t.Fatalf("normalizeMarket() fetchedAt mismatch: got %v want %v", got.FetchedAt, fetchedAt)
+		}
+	})
+
+	t.Run("null prices become zero", func(t *testing.T) {
+		t.Parallel()
+
+		in := GammaMarket{
+			OutcomePrices: json.RawMessage(`null`),
+		}
+		got := normalizeMarket(in, fetchedAt)
+		if got.YesPrice != 0 || got.NoPrice != 0 {
+			t.Fatalf("normalizeMarket() expected zero prices, got yes=%v no=%v", got.YesPrice, got.NoPrice)
+		}
+	})
+}
+
+func TestValidSID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sid  string
+		want bool
+	}{
+		{name: "uuid like", sid: "550e8400-e29b-41d4-a716", want: true},
+		{name: "min length 8", sid: "abcd1234", want: true},
+		{name: "too short", sid: "abc", want: false},
+		{name: "too long", sid: strings.Repeat("a", 129), want: false},
+		{name: "special chars", sid: "sid!@#", want: false},
+		{name: "empty", sid: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validSID.MatchString(tc.sid)
+			if got != tc.want {
+				t.Fatalf("validSID.MatchString(%q) = %v, want %v", tc.sid, got, tc.want)
+			}
+		})
+	}
+}

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -134,8 +135,9 @@ type Server struct {
 	ch      *amqp.Channel
 	chMu    sync.Mutex
 	rdb     *redis.Client
-	db      *pgxpool.Pool
+	db      stateDB
 	backend string
+	state   StateStore
 	cache   struct {
 		sync.RWMutex
 		markets []MarketSnapshot
@@ -586,34 +588,20 @@ func (s *Server) handleGetState(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 
-	if s.backend == "postgres" {
-		var val []byte
-		err := s.db.QueryRow(ctx, "SELECT runtime.session_get($1)", sid).Scan(&val)
-		if err != nil {
-			http.Error(w, "state unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		if val == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte("{}"))
-			return
-		}
+	val, err := s.state.GetState(ctx, sid)
+	if errors.Is(err, ErrStateNotFound) {
+		// No state stored yet for this session — return empty object so
+		// callers don't need to special-case 404 vs. empty state.
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(val)
-	} else {
-		val, err := s.rdb.Get(ctx, "session:"+sid).Result()
-		if err == redis.Nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte("{}"))
-			return
-		}
-		if err != nil {
-			http.Error(w, "state unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(val))
+		w.Write([]byte("{}"))
+		return
 	}
+	if err != nil {
+		http.Error(w, "state unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(val)
 }
 
 func (s *Server) handlePostState(w http.ResponseWriter, r *http.Request) {
@@ -641,17 +629,9 @@ func (s *Server) handlePostState(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 
-	if s.backend == "postgres" {
-		_, pgErr := s.db.Exec(ctx, "SELECT runtime.session_set($1, $2::jsonb, '24 hours')", sid, body)
-		if pgErr != nil {
-			http.Error(w, "state unavailable", http.StatusServiceUnavailable)
-			return
-		}
-	} else {
-		if err := s.rdb.Set(ctx, "session:"+sid, string(body), 24*time.Hour).Err(); err != nil {
-			http.Error(w, "state unavailable", http.StatusServiceUnavailable)
-			return
-		}
+	if err := s.state.SetState(ctx, sid, body); err != nil {
+		http.Error(w, "state unavailable", http.StatusServiceUnavailable)
+		return
 	}
 }
 
@@ -694,6 +674,7 @@ func main() {
 		}
 		defer pool.Close()
 		srv.db = pool
+		srv.state = &postgresStateStore{db: pool}
 		log.Println("Connected to PostgreSQL (postgres mode)")
 
 	default: // "external" — current RabbitMQ + Redis behavior
@@ -722,6 +703,7 @@ func main() {
 			log.Fatalf("parse redis url: %v", err)
 		}
 		srv.rdb = redis.NewClient(redisOpts)
+		srv.state = &redisStateStore{c: srv.rdb}
 		pingCtx, pingCancel := context.WithTimeout(context.Background(), 3*time.Second)
 		if pingErr := srv.rdb.Ping(pingCtx).Err(); pingErr != nil {
 			log.Printf("Warning: Redis not reachable: %v — /state will return 503", pingErr)
@@ -730,7 +712,6 @@ func main() {
 		}
 		pingCancel()
 	}
-
 	// Populate market cache immediately, then refresh independently of UI requests.
 	go func() {
 		srv.fetchAndUpdateMarkets()

--- a/proxy/middleware_test.go
+++ b/proxy/middleware_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCorsMiddlewareGETSetsHeadersAndCallsNext(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if !called {
+		t.Fatal("expected wrapped handler to be called")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want *", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Methods"); got != "GET, OPTIONS" {
+		t.Fatalf("Access-Control-Allow-Methods = %q, want %q", got, "GET, OPTIONS")
+	}
+	assertNoStoreHeaders(t, rr.Header())
+}
+
+func TestCorsMiddlewareOptionsReturnsNoContent(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if called {
+		t.Fatal("expected wrapped handler not to be called for OPTIONS")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+	assertNoStoreHeaders(t, rr.Header())
+}
+
+func TestCorsMiddlewareWithPostAllowsPostAndOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("options has post in allow methods", func(t *testing.T) {
+		t.Parallel()
+		h := corsMiddlewareWithPost(func(w http.ResponseWriter, r *http.Request) {})
+		req := httptest.NewRequest(http.MethodOptions, "/state", nil)
+		rr := httptest.NewRecorder()
+		h(rr, req)
+
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+		}
+		if got := rr.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, OPTIONS" {
+			t.Fatalf("Access-Control-Allow-Methods = %q, want %q", got, "GET, POST, OPTIONS")
+		}
+	})
+
+	t.Run("post calls wrapped handler", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		h := corsMiddlewareWithPost(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusCreated)
+		})
+		req := httptest.NewRequest(http.MethodPost, "/state?sid=abcd1234", nil)
+		rr := httptest.NewRecorder()
+		h(rr, req)
+
+		if !called {
+			t.Fatal("expected wrapped handler to be called for POST")
+		}
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusCreated)
+		}
+	})
+}
+
+func TestSetNoStoreHeaders(t *testing.T) {
+	t.Parallel()
+
+	rr := httptest.NewRecorder()
+	setNoStoreHeaders(rr)
+	assertNoStoreHeaders(t, rr.Header())
+}
+
+func assertNoStoreHeaders(t *testing.T, h http.Header) {
+	t.Helper()
+	if got := h.Get("Cache-Control"); got != "no-store, no-cache, must-revalidate, proxy-revalidate" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if got := h.Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma = %q, want no-cache", got)
+	}
+	if got := h.Get("Expires"); got != "0" {
+		t.Fatalf("Expires = %q, want 0", got)
+	}
+}

--- a/proxy/state_store.go
+++ b/proxy/state_store.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/redis/go-redis/v9"
+)
+
+// StateStore abstracts session-state persistence across runtime backends.
+type StateStore interface {
+	GetState(ctx context.Context, sid string) ([]byte, error)
+	SetState(ctx context.Context, sid string, value []byte) error
+}
+
+var ErrStateNotFound = errors.New("state not found")
+
+type stateDB interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+type redisStateStore struct {
+	c *redis.Client
+}
+
+func (r *redisStateStore) GetState(ctx context.Context, sid string) ([]byte, error) {
+	val, err := r.c.Get(ctx, "session:"+sid).Result()
+	if err == redis.Nil {
+		return nil, ErrStateNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []byte(val), nil
+}
+
+func (r *redisStateStore) SetState(ctx context.Context, sid string, value []byte) error {
+	return r.c.Set(ctx, "session:"+sid, string(value), 24*time.Hour).Err()
+}
+
+type postgresStateStore struct {
+	db stateDB
+}
+
+func (p *postgresStateStore) GetState(ctx context.Context, sid string) ([]byte, error) {
+	var val []byte
+	err := p.db.QueryRow(ctx, "SELECT runtime.session_get($1)", sid).Scan(&val)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, ErrStateNotFound
+	}
+	return val, nil
+}
+
+func (p *postgresStateStore) SetState(ctx context.Context, sid string, value []byte) error {
+	_, err := p.db.Exec(ctx, "SELECT runtime.session_set($1, $2::jsonb, '24 hours')", sid, value)
+	return err
+}

--- a/proxy/state_store_test.go
+++ b/proxy/state_store_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type mockStateRow struct {
+	value []byte
+	err   error
+}
+
+func (r mockStateRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) != 1 {
+		return errors.New("unexpected scan destination count")
+	}
+	out, ok := dest[0].(*[]byte)
+	if !ok {
+		return errors.New("unexpected scan destination type")
+	}
+	if r.value == nil {
+		*out = nil
+		return nil
+	}
+	*out = append([]byte(nil), r.value...)
+	return nil
+}
+
+type mockStateDB struct {
+	queryRowValue []byte
+	queryRowErr   error
+	querySQL      string
+	queryArgs     []any
+	execErr       error
+	execSQL       string
+	execArgs      []any
+}
+
+func (m *mockStateDB) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
+	m.querySQL = sql
+	m.queryArgs = append([]any(nil), args...)
+	return mockStateRow{value: m.queryRowValue, err: m.queryRowErr}
+}
+
+func (m *mockStateDB) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	m.execSQL = sql
+	m.execArgs = append([]any(nil), args...)
+	var tag pgconn.CommandTag
+	return tag, m.execErr
+}
+
+func TestPostgresStateStoreGetState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stored state returns bytes", func(t *testing.T) {
+		t.Parallel()
+		db := &mockStateDB{queryRowValue: []byte(`{"a":1}`)}
+		store := &postgresStateStore{db: db}
+
+		got, err := store.GetState(context.Background(), "abcd1234")
+		if err != nil {
+			t.Fatalf("GetState() error = %v", err)
+		}
+		if string(got) != `{"a":1}` {
+			t.Fatalf("GetState() = %q, want %q", string(got), `{"a":1}`)
+		}
+		if db.querySQL != "SELECT runtime.session_get($1)" {
+			t.Fatalf("query SQL = %q", db.querySQL)
+		}
+		if len(db.queryArgs) != 1 || db.queryArgs[0] != "abcd1234" {
+			t.Fatalf("query args = %#v", db.queryArgs)
+		}
+	})
+
+	t.Run("nil row becomes not found", func(t *testing.T) {
+		t.Parallel()
+		store := &postgresStateStore{db: &mockStateDB{}}
+
+		_, err := store.GetState(context.Background(), "abcd1234")
+		if !errors.Is(err, ErrStateNotFound) {
+			t.Fatalf("GetState() error = %v, want ErrStateNotFound", err)
+		}
+	})
+
+	t.Run("db error bubbles up", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("boom")
+		store := &postgresStateStore{db: &mockStateDB{queryRowErr: boom}}
+
+		_, err := store.GetState(context.Background(), "abcd1234")
+		if !errors.Is(err, boom) {
+			t.Fatalf("GetState() error = %v, want %v", err, boom)
+		}
+	})
+}
+
+func TestPostgresStateStoreSetState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes via runtime.session_set", func(t *testing.T) {
+		t.Parallel()
+		db := &mockStateDB{}
+		store := &postgresStateStore{db: db}
+
+		if err := store.SetState(context.Background(), "abcd1234", []byte(`{"a":1}`)); err != nil {
+			t.Fatalf("SetState() error = %v", err)
+		}
+		if db.execSQL != "SELECT runtime.session_set($1, $2::jsonb, '24 hours')" {
+			t.Fatalf("exec SQL = %q", db.execSQL)
+		}
+		if len(db.execArgs) != 2 || db.execArgs[0] != "abcd1234" {
+			t.Fatalf("exec args = %#v", db.execArgs)
+		}
+		body, ok := db.execArgs[1].([]byte)
+		if !ok || string(body) != `{"a":1}` {
+			t.Fatalf("exec body arg = %#v", db.execArgs[1])
+		}
+	})
+
+	t.Run("db error bubbles up", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("boom")
+		store := &postgresStateStore{db: &mockStateDB{execErr: boom}}
+
+		err := store.SetState(context.Background(), "abcd1234", []byte(`{"a":1}`))
+		if !errors.Is(err, boom) {
+			t.Fatalf("SetState() error = %v, want %v", err, boom)
+		}
+	})
+}


### PR DESCRIPTION
Closes #34

**Change summary**
- Introduce `StateStore` interface + `redisStateStore` adapter in `proxy/main.go`;
  rewrite `handleGetState` / `handlePostState` to call `s.state` instead of `s.rdb`
  directly — zero runtime behavior change, enables mock injection in tests
- Add `proxy/helpers_test.go`: table-driven unit tests for `toFloat`,
  `parseOutcomePrices`, `normalizeMarket`, and `validSID` regex
- Add `proxy/middleware_test.go`: tests for `corsMiddleware`,
  `corsMiddlewareWithPost`, and `setNoStoreHeaders`
- Add `proxy/handlers_test.go`: `httptest`-based tests for `handleHealth`,
  `handleWhales`, `handlePrices`, `handleCurrent` (cache hit + 502 fallback),
  `handleState` routing, `handleGetState`, `handlePostState`
  (400 / 200 / 503 / empty-`{}` cases) — all via `mockStateStore`, no external deps
- Update `CLAUDE.md` and `AGENTS.md` with `go test ./...` command reference

**Affected services** (delete lines that don't apply)
- [x] Go Proxy (`proxy/`)
- [x] Docs only

**Local verification** (check every box that applies — see CONTRIBUTING.md)
- [x] Go: `go test ./...` + `go build ./...` clean
- [x] `go vet ./...` clean (recommended per CONTRIBUTING.md)

**Test plan**
- [x] `go test ./...` from `proxy/` — all tests pass without Docker Compose,
      Redis, RabbitMQ, or PostgreSQL
- [x] Tests are deterministic and have no sleep or network calls

**Carry-over list**
- After PR #29 (`feature/proxy-postgres-runtime`) merges, add
  `pgStateStore` mock and extend `/state` handler tests to cover the
  `postgres` backend path — this is intentionally out of scope here

- [x] Docs updated (CLAUDE.md, AGENTS.md)
- [ ] Breaking change? No