### PR TITLE
ci: allow PR checks on dev

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,10 @@
 name: PR Checks
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
## Summary

- Add workflow_dispatch to PR Checks so the workflow can be run manually against dev.
- Add a push trigger for dev so the same checks run after merges.

## Verification

- git diff --check